### PR TITLE
Add -Ywarn-unused scalac option

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -12,7 +12,7 @@ object BuildHelper {
       name                     := s"$prjName",
       crossScalaVersions       := List(Scala212, Scala213),
       ThisBuild / scalaVersion := Scala213,
-      scalacOptions            := stdOptions,
+      scalacOptions            := stdOptions ++ extraOptions,
       semanticdbEnabled        := true,
       semanticdbOptions += "-P:semanticdb:synthetics:on",
       semanticdbVersion                                          := scalafixSemanticdb.revision,
@@ -22,6 +22,9 @@ object BuildHelper {
       incOptions ~= (_.withLogRecompileOnMacro(false)),
       autoAPIMappings := true
     )
+
+  private val extraOptions =
+    List("-Ywarn-unused")
 
   private val stdOptions =
     List("-deprecation", "-encoding", "UTF-8", "-feature", "-unchecked", "-Xfatal-warnings")


### PR DESCRIPTION
### Summary

- Adds `-Ywarn-unused` scalac option to the subprojects, which is required for the `OrganizeImports.removeUnused` external scalafix rule.
- It should be noted that OrganizeImports [isn't built for the currently used scalafix version](https://github.com/liancheng/scalafix-organize-imports/issues/277), but it doesn't seem to cause any issues.