### PR TITLE
(dsl): Provide `createIndex` methods

### DIFF
--- a/modules/example/src/main/scala/example/Main.scala
+++ b/modules/example/src/main/scala/example/Main.scala
@@ -54,7 +54,7 @@ object Main extends ZIOAppDefault {
       for {
         _       <- ZIO.logInfo(s"Creating index '$Index'...")
         mapping <- ZIO.fromTry(Using(Source.fromURL(getClass.getResource("/mapping.json")))(_.mkString))
-        _       <- Elasticsearch.execute(ElasticRequest.createIndex(Index, Some(mapping)))
+        _       <- Elasticsearch.execute(ElasticRequest.createIndex(Index, mapping))
       } yield ()
 
     val populate: RIO[SttpBackend[Task, Any] with Elasticsearch, Unit] =

--- a/modules/library/src/it/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/library/src/it/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -53,12 +53,12 @@ object HttpExecutorSpec extends IntegrationSpec {
         ),
         suite("creating index")(
           test("successfully create index") {
-            assertZIO(ElasticExecutor.execute(ElasticRequest.createIndex(createIndexTestName, None)))(equalTo(Created))
+            assertZIO(ElasticExecutor.execute(ElasticRequest.createIndex(createIndexTestName)))(equalTo(Created))
           },
           test("return 'AlreadyExists' if index already exists") {
             for {
-              _   <- ElasticExecutor.execute(ElasticRequest.createIndex(createIndexTestName, None))
-              res <- ElasticExecutor.execute(ElasticRequest.createIndex(createIndexTestName, None))
+              _   <- ElasticExecutor.execute(ElasticRequest.createIndex(createIndexTestName))
+              res <- ElasticExecutor.execute(ElasticRequest.createIndex(createIndexTestName))
             } yield assert(res)(equalTo(AlreadyExists))
           }
         ) @@ after(ElasticExecutor.execute(ElasticRequest.deleteIndex(createIndexTestName)).orDie),
@@ -100,7 +100,7 @@ object HttpExecutorSpec extends IntegrationSpec {
           test("successfully delete existing index") {
             checkOnce(genIndexName) { name =>
               for {
-                _   <- ElasticExecutor.execute(ElasticRequest.createIndex(name, None))
+                _   <- ElasticExecutor.execute(ElasticRequest.createIndex(name))
                 res <- ElasticExecutor.execute(ElasticRequest.deleteIndex(name))
               } yield assert(res)(equalTo(Deleted))
             }
@@ -174,7 +174,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                 } yield assert(res)(isNonEmpty)
             }
           } @@ around(
-            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex, None)),
+            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             ElasticExecutor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           ),
           test("fail if any of results cannot be decoded") {
@@ -205,7 +205,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                 )
             }
           } @@ around(
-            ElasticExecutor.execute(ElasticRequest.createIndex(secondSearchIndex, None)),
+            ElasticExecutor.execute(ElasticRequest.createIndex(secondSearchIndex)),
             ElasticExecutor.execute(ElasticRequest.deleteIndex(secondSearchIndex)).orDie
           ),
           test("search for a document which contains a term using a wildcard query") {
@@ -228,7 +228,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                 } yield assert(res)(Assertion.contains(firstCustomer))
             }
           } @@ around(
-            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex, None)),
+            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             ElasticExecutor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           ),
           test("search for a document which starts with a term using a wildcard query") {
@@ -251,7 +251,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                 } yield assert(res)(Assertion.contains(firstCustomer))
             }
           } @@ around(
-            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex, None)),
+            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             ElasticExecutor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           ),
           test("search for a document which conforms to a pattern using a wildcard query") {
@@ -275,7 +275,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                 } yield assert(res)(Assertion.contains(firstCustomer))
             }
           } @@ around(
-            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex, None)),
+            ElasticExecutor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             ElasticExecutor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           )
         ) @@ shrinks(0),
@@ -318,7 +318,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                 } yield assert(res)(hasSameElements(List(firstCustomer.copy(balance = 150))))
             }
           } @@ around(
-            ElasticExecutor.execute(ElasticRequest.createIndex(deleteByQueryIndex, None)),
+            ElasticExecutor.execute(ElasticRequest.createIndex(deleteByQueryIndex)),
             ElasticExecutor.execute(ElasticRequest.deleteIndex(deleteByQueryIndex)).orDie
           ),
           test("returns NotFound when provided index is missing") {

--- a/modules/library/src/it/scala/zio/elasticsearch/IntegrationSpec.scala
+++ b/modules/library/src/it/scala/zio/elasticsearch/IntegrationSpec.scala
@@ -40,7 +40,7 @@ trait IntegrationSpec extends ZIOSpecDefault {
   val createIndexTestName: IndexName = IndexName("create-index-test-name")
 
   val prepareElasticsearchIndexForTests: TestAspect[Nothing, Any, Throwable, Any] = beforeAll((for {
-    _ <- ElasticExecutor.execute(ElasticRequest.createIndex(index, None))
+    _ <- ElasticExecutor.execute(ElasticRequest.createIndex(index))
     _ <- ElasticExecutor.execute(ElasticRequest.deleteByQuery(index, matchAll).refreshTrue)
   } yield ()).provide(elasticsearchLayer))
 

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticRequest.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticRequest.scala
@@ -55,8 +55,11 @@ object ElasticRequest {
   def create[A: Schema](index: IndexName, id: DocumentId, doc: A): ElasticRequest[CreationOutcome, CreateWithId] =
     CreateWithIdRequest(index = index, id = id, document = Document.from(doc), refresh = false, routing = None)
 
-  def createIndex(name: IndexName, definition: Option[String]): ElasticRequest[CreationOutcome, CreateIndex] =
-    CreateIndexRequest(name, definition)
+  def createIndex(name: IndexName): ElasticRequest[CreationOutcome, CreateIndex] =
+    CreateIndexRequest(name = name, definition = None)
+
+  def createIndex(name: IndexName, definition: String): ElasticRequest[CreationOutcome, CreateIndex] =
+    CreateIndexRequest(name = name, definition = Some(definition))
 
   def deleteById(index: IndexName, id: DocumentId): ElasticRequest[DeletionOutcome, DeleteById] =
     DeleteByIdRequest(index = index, id = id, refresh = false, routing = None)
@@ -95,7 +98,7 @@ object ElasticRequest {
     }
 
   def upsert[A: Schema](index: IndexName, id: DocumentId, doc: A): ElasticRequest[Unit, Upsert] =
-    CreateOrUpdateRequest(index, id, Document.from(doc), refresh = false, routing = None)
+    CreateOrUpdateRequest(index = index, id = id, document = Document.from(doc), refresh = false, routing = None)
 
   private[elasticsearch] final case class BulkableRequest private (request: ElasticRequest[_, _])
 


### PR DESCRIPTION
### Description: 

Instead of having one public method for creating index - `def createIndex(name: IndexName, definition: Option[String])`, I separated that into two methods, avoiding `Option`. 

```
def createIndex(name: IndexName)

def createIndex(name: IndexName, definition: String)
```