### PR TITLE
(dsl): Support 'matchPhrase' query

### DIFF
--- a/docs/overview/queries/elastic_query_match_phrase.md
+++ b/docs/overview/queries/elastic_query_match_phrase.md
@@ -1,0 +1,6 @@
+---
+id: elastic_query_match_phrase
+title: "Match Phrase Query"
+---
+
+TBD

--- a/modules/example/src/main/scala/example/api/ErrorResponse.scala
+++ b/modules/example/src/main/scala/example/api/ErrorResponse.scala
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package example
+package example.api
 
-import zio.http.Request
+import zio.Chunk
+import zio.json.{DeriveJsonEncoder, JsonEncoder}
 
-package object api {
-  implicit final class RequestOps(private val req: Request) extends AnyVal {
-    def limit: Int = req.url.queryParams.get("limit").flatMap(_.headOption).flatMap(_.toIntOption).getOrElse(10)
+final case class ErrorResponse(errors: ErrorResponseData)
 
-    def offset: Int = req.url.queryParams.get("offset").flatMap(_.headOption).flatMap(_.toIntOption).getOrElse(0)
-  }
+object ErrorResponse {
+  implicit val encoder: JsonEncoder[ErrorResponse] = DeriveJsonEncoder.gen[ErrorResponse]
+
+  def fromReasons(reasons: String*): ErrorResponse =
+    new ErrorResponse(ErrorResponseData(Chunk.fromIterable(reasons)))
 }

--- a/modules/example/src/main/scala/example/api/ErrorResponseData.scala
+++ b/modules/example/src/main/scala/example/api/ErrorResponseData.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package example
+package example.api
 
-import zio.http.Request
+import zio.Chunk
+import zio.json.{DeriveJsonEncoder, JsonEncoder}
 
-package object api {
-  implicit final class RequestOps(private val req: Request) extends AnyVal {
-    def limit: Int = req.url.queryParams.get("limit").flatMap(_.headOption).flatMap(_.toIntOption).getOrElse(10)
+final case class ErrorResponseData(body: Chunk[String])
 
-    def offset: Int = req.url.queryParams.get("offset").flatMap(_.headOption).flatMap(_.toIntOption).getOrElse(0)
-  }
+object ErrorResponseData {
+  implicit val encoder: JsonEncoder[ErrorResponseData] = DeriveJsonEncoder.gen[ErrorResponseData]
 }

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -118,7 +118,7 @@ object ElasticQuery {
 
   /**
    * Constructs a type-safe instance of [[MatchQuery]] using the specified parameters. [[MatchQuery]] is used for
-   * matching a provided text, number, date or boolean value
+   * matching a provided text, number, date or boolean value.
    *
    * @param field
    *   the [[Field]] object representing the type-safe field for which query is specified for
@@ -136,7 +136,7 @@ object ElasticQuery {
 
   /**
    * Constructs an instance of [[MatchQuery]] using the specified parameters. [[MatchQuery]] is used for matching a
-   * provided text, number, date or boolean value
+   * provided text, number, date or boolean value.
    *
    * @param field
    *   the field for which query is specified for
@@ -149,6 +149,27 @@ object ElasticQuery {
    */
   final def matches[A: ElasticPrimitive](field: String, value: A): MatchQuery[Any] =
     Match(field = field, value = value)
+
+  /**
+   * Constructs a type-safe instance of [[MatchPhraseQuery]] using the specified parameters. [[MatchPhraseQuery]]
+   * analyzes the text and creates a phrase query out of the analyzed text.
+   *
+   * @param field
+   *   the [[Field]] object representing the type-safe field for which query is specified for
+   * @param value
+   *   the value to be matched, represented by an instance of type `A`
+   * @tparam S
+   *   document for which field query is executed
+   * @tparam A
+   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   * @return
+   *   an instance of [[MatchQuery]] that represents the match query to be performed.
+   */
+  final def matchPhrase[S, A: ElasticPrimitive](field: Field[S, A], value: A): MatchPhraseQuery[S] =
+    MatchPhrase(field = field.toString, value = value)
+
+  final def matchPhrase[A: ElasticPrimitive](field: String, value: A): MatchPhraseQuery[Any] =
+    MatchPhrase(field = field, value = value)
 
   /**
    * Constructs an instance of [[BoolQuery]] with queries that must satisfy the criteria using the specified parameters.

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -155,7 +155,7 @@ object ElasticQuery {
    * analyzes the text and creates a phrase query out of the analyzed text.
    *
    * @param field
-   *   the [[Field]] object representing the type-safe field for which query is specified for
+   *   the field for which query is specified for
    * @param value
    *   the value to be matched, represented by an instance of type `A`
    * @tparam S

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -132,7 +132,7 @@ object ElasticQuery {
    *   an instance of [[MatchQuery]] that represents the match query to be performed.
    */
   final def matches[S, A: ElasticPrimitive](field: Field[S, A], value: A): MatchQuery[S] =
-    Match(field = field.toString, value = value)
+    Match(field = field.toString, value = value, boost = None)
 
   /**
    * Constructs an instance of [[MatchQuery]] using the specified parameters. [[MatchQuery]] is used for matching a
@@ -148,7 +148,7 @@ object ElasticQuery {
    *   an instance of [[MatchQuery]] that represents the match query to be performed.
    */
   final def matches[A: ElasticPrimitive](field: String, value: A): MatchQuery[Any] =
-    Match(field = field, value = value)
+    Match(field = field, value = value, boost = None)
 
   /**
    * Constructs a type-safe instance of [[MatchPhraseQuery]] using the specified parameters. [[MatchPhraseQuery]]
@@ -164,7 +164,7 @@ object ElasticQuery {
    *   an instance of [[MatchQuery]] that represents the match query to be performed.
    */
   final def matchPhrase[S](field: Field[S, String], value: String): MatchPhraseQuery[S] =
-    MatchPhrase(field = field.toString, value = value)
+    MatchPhrase(field = field.toString, value = value, boost = None)
 
   /**
    * Constructs an instance of [[MatchPhraseQuery]] using the specified parameters. [[MatchPhraseQuery]] analyzes the
@@ -182,7 +182,7 @@ object ElasticQuery {
    *   an instance of [[MatchQuery]] that represents the match query to be performed.
    */
   final def matchPhrase(field: String, value: String): MatchPhraseQuery[Any] =
-    MatchPhrase(field = field, value = value)
+    MatchPhrase(field = field, value = value, boost = None)
 
   /**
    * Constructs an instance of [[BoolQuery]] with queries that must satisfy the criteria using the specified parameters.

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -160,15 +160,28 @@ object ElasticQuery {
    *   the value to be matched, represented by an instance of type `A`
    * @tparam S
    *   document for which field query is executed
+   * @return
+   *   an instance of [[MatchQuery]] that represents the match query to be performed.
+   */
+  final def matchPhrase[S](field: Field[S, String], value: String): MatchPhraseQuery[S] =
+    MatchPhrase(field = field.toString, value = value)
+
+  /**
+   * Constructs an instance of [[MatchPhraseQuery]] using the specified parameters. [[MatchPhraseQuery]] analyzes the
+   * text and creates a phrase query out of the analyzed text.
+   *
+   * @param field
+   *   the [[Field]] object representing the type-safe field for which query is specified for
+   * @param value
+   *   the value to be matched, represented by an instance of type `A`
+   * @tparam S
+   *   document for which field query is executed
    * @tparam A
    *   the type of value to be matched. A JSON decoder must be in scope for this type
    * @return
    *   an instance of [[MatchQuery]] that represents the match query to be performed.
    */
-  final def matchPhrase[S, A: ElasticPrimitive](field: Field[S, A], value: A): MatchPhraseQuery[S] =
-    MatchPhrase(field = field.toString, value = value)
-
-  final def matchPhrase[A: ElasticPrimitive](field: String, value: A): MatchPhraseQuery[Any] =
+  final def matchPhrase(field: String, value: String): MatchPhraseQuery[Any] =
     MatchPhrase(field = field, value = value)
 
   /**

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -161,7 +161,7 @@ object ElasticQuery {
    * @tparam S
    *   document for which field query is executed
    * @return
-   *   an instance of [[MatchQuery]] that represents the match query to be performed.
+   *   an instance of [[MatchPhraseQuery]] that represents the match phrase query to be performed.
    */
   final def matchPhrase[S](field: Field[S, String], value: String): MatchPhraseQuery[S] =
     MatchPhrase(field = field.toString, value = value, boost = None)
@@ -174,12 +174,8 @@ object ElasticQuery {
    *   the [[Field]] object representing the type-safe field for which query is specified for
    * @param value
    *   the value to be matched, represented by an instance of type `A`
-   * @tparam S
-   *   document for which field query is executed
-   * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
    * @return
-   *   an instance of [[MatchQuery]] that represents the match query to be performed.
+   *   an instance of [[MatchPhraseQuery]] that represents the match phrase query to be performed.
    */
   final def matchPhrase(field: String, value: String): MatchPhraseQuery[Any] =
     MatchPhrase(field = field, value = value, boost = None)

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -103,11 +103,17 @@ private[elasticsearch] final case class Exists[S](field: String) extends ExistsQ
     Obj("exists" -> Obj("field" -> fieldPath.foldRight(field)(_ + "." + _).toJson))
 }
 
-sealed trait MatchQuery[S] extends ElasticQuery[S]
+sealed trait MatchQuery[S] extends ElasticQuery[S] with HasBoost[MatchQuery[S]]
 
-private[elasticsearch] final case class Match[S, A: ElasticPrimitive](field: String, value: A) extends MatchQuery[S] {
-  def paramsToJson(fieldPath: Option[String]): Json =
-    Obj("match" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson))
+private[elasticsearch] final case class Match[S, A: ElasticPrimitive](field: String, value: A, boost: Option[Double])
+    extends MatchQuery[S] { self =>
+  def boost(value: Double): MatchQuery[S] =
+    self.copy(boost = Some(value))
+
+  def paramsToJson(fieldPath: Option[String]): Json = {
+    val matchFields = Some(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson) ++ boost.map("boost" -> Num(_))
+    Obj("match" -> Obj(matchFields.toList: _*))
+  }
 }
 
 sealed trait MatchAllQuery extends ElasticQuery[Any] with HasBoost[MatchAllQuery]
@@ -120,11 +126,18 @@ private[elasticsearch] final case class MatchAll(boost: Option[Double]) extends 
     Obj("match_all" -> Obj(boost.map("boost" -> Num(_)).toList: _*))
 }
 
-sealed trait MatchPhraseQuery[S] extends ElasticQuery[S]
+sealed trait MatchPhraseQuery[S] extends ElasticQuery[S] with HasBoost[MatchPhraseQuery[S]]
 
-private[elasticsearch] final case class MatchPhrase[S](field: String, value: String) extends MatchPhraseQuery[S] {
-  def paramsToJson(fieldPath: Option[String]): Json =
-    Obj("match_phrase" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson))
+private[elasticsearch] final case class MatchPhrase[S](field: String, value: String, boost: Option[Double])
+    extends MatchPhraseQuery[S] { self =>
+  def boost(value: Double): MatchPhraseQuery[S] =
+    self.copy(boost = Some(value))
+
+  def paramsToJson(fieldPath: Option[String]): Json = {
+    val matchPhraseFields =
+      Some(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson) ++ boost.map("boost" -> Num(_))
+    Obj("match_phrase" -> Obj(matchPhraseFields.toList: _*))
+  }
 }
 
 sealed trait NestedQuery[S]

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -122,8 +122,7 @@ private[elasticsearch] final case class MatchAll(boost: Option[Double]) extends 
 
 sealed trait MatchPhraseQuery[S] extends ElasticQuery[S]
 
-private[elasticsearch] final case class MatchPhrase[S, A: ElasticPrimitive](field: String, value: A)
-    extends MatchPhraseQuery[S] {
+private[elasticsearch] final case class MatchPhrase[S](field: String, value: String) extends MatchPhraseQuery[S] {
   def paramsToJson(fieldPath: Option[String]): Json =
     Obj("match_phrase" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson))
 }

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -1029,6 +1029,89 @@ object QueryDSLSpec extends ZIOSpecDefault {
 
           assert(query.toJson)(equalTo(expected.toJson))
         },
+        test("successfully construct MatchPhrase query") {
+          val querySimple      = matchPhrase(field = "stringField", value = "this is a test")
+          val queryRaw         = matchPhrase(field = "stringField.raw", value = "this is a test")
+          val queryWithBoost   = matchPhrase(field = "stringField", value = "this is a test").boost(21.15)
+          val querySimpleTs    = matchPhrase(field = TestDocument.stringField, value = "this is a test")
+          val queryRawTs       = matchPhrase(field = TestDocument.stringField.raw, value = "this is a test")
+          val queryWithBoostTs = matchPhrase(field = TestDocument.stringField, value = "this is a test").boost(21.15)
+
+          assert(querySimple)(
+            equalTo(MatchPhrase[Any](field = "stringField", value = "this is a test", boost = None))
+          ) && assert(querySimpleTs)(
+            equalTo(MatchPhrase[TestDocument](field = "stringField", value = "this is a test", boost = None))
+          ) && assert(queryRaw)(
+            equalTo(MatchPhrase[Any](field = "stringField.raw", value = "this is a test", boost = None))
+          ) && assert(queryRawTs)(
+            equalTo(MatchPhrase[TestDocument](field = "stringField.raw", value = "this is a test", boost = None))
+          ) && assert(queryWithBoost)(
+            equalTo(MatchPhrase[Any](field = "stringField", value = "this is a test", boost = Some(21.15)))
+          ) && assert(queryWithBoostTs)(
+            equalTo(MatchPhrase[TestDocument](field = "stringField", value = "this is a test", boost = Some(21.15)))
+          )
+        },
+        test("successfully encode MatchPhrase query") {
+          val querySimple      = matchPhrase(field = "stringField", value = "this is a test")
+          val queryRaw         = matchPhrase(field = "stringField.raw", value = "this is a test")
+          val queryWithBoost   = matchPhrase(field = "stringField", value = "this is a test").boost(21.15)
+          val querySimpleTs    = matchPhrase(field = TestDocument.stringField, value = "this is a test")
+          val queryRawTs       = matchPhrase(field = TestDocument.stringField.raw, value = "this is a test")
+          val queryWithBoostTs = matchPhrase(field = TestDocument.stringField, value = "this is a test").boost(21.15)
+
+          val querySimpleExpectedJson =
+            """
+              |{
+              |  "query": {
+              |    "match_phrase": {
+              |      "stringField": "this is a test"
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          val queryRawExpectedJson =
+            """
+              |{
+              |  "query": {
+              |    "match_phrase": {
+              |      "stringField.raw": "this is a test"
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          val queryWithBoostExpectedJson =
+            """
+              |{
+              |  "query": {
+              |    "match_phrase": {
+              |      "stringField": "this is a test",
+              |      "boost": 21.15
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(querySimple.toJson)(equalTo(querySimpleExpectedJson.toJson)) && assert(querySimpleTs.toJson)(
+            equalTo(querySimpleExpectedJson.toJson)
+          ) &&
+          assert(queryRaw.toJson)(equalTo(queryRawExpectedJson.toJson)) && assert(queryRawTs.toJson)(
+            equalTo(queryRawExpectedJson.toJson)
+          ) &&
+          assert(queryWithBoost.toJson)(equalTo(queryWithBoostExpectedJson.toJson)) && assert(queryWithBoostTs.toJson)(
+            equalTo(queryWithBoostExpectedJson.toJson)
+          )
+        },
+        test("successfully create type-safe Match query using `matches` method") {
+          val queryString = matches(field = TestSubDocument.stringField, value = "StringField")
+          val queryInt    = matches(field = TestSubDocument.intField, value = 39)
+
+          assert(queryString)(
+            equalTo(Match[TestSubDocument, String](field = "stringField", value = "StringField", boost = None))
+          ) &&
+          assert(queryInt)(equalTo(Match[TestSubDocument, Int](field = "intField", value = 39, boost = None)))
+        },
         test("properly encode Nested Query with MatchAll Query") {
           val query = nested(path = "customer", query = matchAll)
           val expected =

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -36,21 +36,25 @@ object QueryDSLSpec extends ZIOSpecDefault {
           val queryBool   = matches(field = "day_of_week", value = true)
           val queryLong   = matches(field = "day_of_week", value = 1L)
 
-          assert(queryString)(equalTo(Match[Any, String](field = "day_of_week", value = "Monday"))) &&
-          assert(queryBool)(equalTo(Match[Any, Boolean](field = "day_of_week", value = true))) &&
-          assert(queryLong)(equalTo(Match[Any, Long](field = "day_of_week", value = 1)))
+          assert(queryString)(equalTo(Match[Any, String](field = "day_of_week", value = "Monday", boost = None))) &&
+          assert(queryBool)(equalTo(Match[Any, Boolean](field = "day_of_week", value = true, boost = None))) &&
+          assert(queryLong)(equalTo(Match[Any, Long](field = "day_of_week", value = 1, boost = None)))
         },
         test("successfully create type-safe Match query using `matches` method") {
           val queryString = matches(field = TestSubDocument.stringField, value = "StringField")
           val queryInt    = matches(field = TestSubDocument.intField, value = 39)
 
-          assert(queryString)(equalTo(Match[TestSubDocument, String](field = "stringField", value = "StringField"))) &&
-          assert(queryInt)(equalTo(Match[TestSubDocument, Int](field = "intField", value = 39)))
+          assert(queryString)(
+            equalTo(Match[TestSubDocument, String](field = "stringField", value = "StringField", boost = None))
+          ) &&
+          assert(queryInt)(equalTo(Match[TestSubDocument, Int](field = "intField", value = 39, boost = None)))
         },
         test("successfully create type-safe Match query with suffix using `matches` method") {
           val query = matches(field = TestSubDocument.stringField.keyword, value = "StringField")
 
-          assert(query)(equalTo(Match[TestSubDocument, String](field = "stringField.keyword", value = "StringField")))
+          assert(query)(
+            equalTo(Match[TestSubDocument, String](field = "stringField.keyword", value = "StringField", boost = None))
+          )
         },
         test("successfully create `Filter` query from two Match queries") {
           val query = filter(
@@ -62,8 +66,8 @@ object QueryDSLSpec extends ZIOSpecDefault {
             equalTo(
               Bool[TestDocument](
                 filter = List(
-                  Match(field = "stringField", value = "StringField"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "stringField", value = "StringField", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
                 must = Nil,
                 mustNot = Nil,
@@ -83,8 +87,8 @@ object QueryDSLSpec extends ZIOSpecDefault {
             equalTo(
               Bool[TestDocument](
                 filter = List(
-                  Match(field = "stringField", value = "StringField"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "stringField", value = "StringField", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
                 must = Nil,
                 mustNot = Nil,
@@ -106,8 +110,8 @@ object QueryDSLSpec extends ZIOSpecDefault {
               Bool[TestDocument](
                 filter = Nil,
                 must = List(
-                  Match(field = "stringField", value = "StringField"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "stringField", value = "StringField", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
                 mustNot = Nil,
                 should = Nil,
@@ -129,8 +133,8 @@ object QueryDSLSpec extends ZIOSpecDefault {
                 filter = Nil,
                 must = Nil,
                 mustNot = List(
-                  Match(field = "stringField", value = "StringField"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "stringField", value = "StringField", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
                 should = Nil,
                 boost = None
@@ -151,8 +155,8 @@ object QueryDSLSpec extends ZIOSpecDefault {
                 must = Nil,
                 mustNot = Nil,
                 should = List(
-                  Match(field = "stringField", value = "StringField"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "stringField", value = "StringField", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
                 boost = None
               )
@@ -172,12 +176,12 @@ object QueryDSLSpec extends ZIOSpecDefault {
             equalTo(
               Bool[TestDocument](
                 filter = List(
-                  Match(field = "stringField", value = "StringField"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "stringField", value = "StringField", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
-                must = List(Match(field = "customer_age", value = 23)),
-                mustNot = List(Match(field = "intField", value = 17)),
-                should = List(Match(field = "customer_id", value = 1)),
+                must = List(Match(field = "customer_age", value = 23, boost = None)),
+                mustNot = List(Match(field = "intField", value = 17, boost = None)),
+                should = List(Match(field = "customer_id", value = 1, boost = None)),
                 boost = None
               )
             )
@@ -195,13 +199,13 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query)(
             equalTo(
               Bool[TestDocument](
-                filter = List(Match(field = "intField", value = 1)),
+                filter = List(Match(field = "intField", value = 1, boost = None)),
                 must = List(
-                  Match(field = "stringField", value = "StringField1"),
-                  Match(field = "stringField", value = "StringField2")
+                  Match(field = "stringField", value = "StringField1", boost = None),
+                  Match(field = "stringField", value = "StringField2", boost = None)
                 ),
-                mustNot = List(Match(field = "intField", value = 17)),
-                should = List(Match(field = "doubleField", value = 23.0)),
+                mustNot = List(Match(field = "intField", value = 17, boost = None)),
+                should = List(Match(field = "doubleField", value = 23.0, boost = None)),
                 boost = None
               )
             )
@@ -219,13 +223,13 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query)(
             equalTo(
               Bool[TestDocument](
-                filter = List(Match(field = "stringField", value = "StringField")),
-                must = List(Match(field = "intField", value = 17)),
+                filter = List(Match(field = "stringField", value = "StringField", boost = None)),
+                must = List(Match(field = "intField", value = 17, boost = None)),
                 mustNot = List(
-                  Match(field = "day_of_week", value = "Monday"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "day_of_week", value = "Monday", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
-                should = List(Match(field = "intField", value = 23)),
+                should = List(Match(field = "intField", value = 23, boost = None)),
                 boost = None
               )
             )
@@ -243,12 +247,12 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query)(
             equalTo(
               Bool[TestDocument](
-                filter = List(Match(field = "stringField", value = "StringField")),
-                must = List(Match(field = "intField", value = 23)),
-                mustNot = List(Match(field = "day_of_month", value = 17)),
+                filter = List(Match(field = "stringField", value = "StringField", boost = None)),
+                must = List(Match(field = "intField", value = 23, boost = None)),
+                mustNot = List(Match(field = "day_of_month", value = 17, boost = None)),
                 should = List(
-                  Match(field = "day_of_week", value = "Monday"),
-                  Match(field = "customer_gender", value = "MALE")
+                  Match(field = "day_of_week", value = "Monday", boost = None),
+                  Match(field = "customer_gender", value = "MALE", boost = None)
                 ),
                 boost = None
               )
@@ -265,10 +269,10 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query)(
             equalTo(
               Bool[TestDocument](
-                filter = List(Match(field = "intField", value = 1)),
-                must = List(Match(field = "doubleField", value = 23.0)),
-                mustNot = List(Match(field = "intField", value = 17)),
-                should = List(Match(field = "stringField", value = "StringField")),
+                filter = List(Match(field = "intField", value = 1, boost = None)),
+                must = List(Match(field = "doubleField", value = 23.0, boost = None)),
+                mustNot = List(Match(field = "intField", value = 17, boost = None)),
+                should = List(Match(field = "stringField", value = "StringField", boost = None)),
                 boost = Some(1.0)
               )
             )

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -19,6 +19,7 @@ module.exports = {
                     'overview/queries/elastic_query_filter',
                     'overview/queries/elastic_query_match_all',
                     'overview/queries/elastic_query_matches',
+                    'overview/queries/elastic_query_match_phrase',
                     'overview/queries/elastic_query_must',
                     'overview/queries/elastic_query_must_not',
                     'overview/queries/elastic_query_nested',


### PR DESCRIPTION
### Description:

Resolves `matchPhraseQuery` in #91

- Provided `matchPhrase` query. 
- Provided `boost` options both for `match` and `matchPhrase` queries.
- Addressed warning for the example app.
- Improved documentation (provided .). 
- Changed the way of constructing fields in `paramsToJson` methods.
- Adapted existing and provided new tests.
- Provided structure for the website.