### PR TITLE
(dsl): Add has parent query

### DIFF
--- a/docs/overview/queries/elastic_query_has_parent.md
+++ b/docs/overview/queries/elastic_query_has_parent.md
@@ -1,0 +1,6 @@
+---
+id: elastic_query_has_parent
+title: "Has Parent Query"
+---
+
+TBD

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -113,9 +113,9 @@ object ElasticQuery {
    * Constructs an instance of [[zio.elasticsearch.query.HasParent]] using the specified parameters.
    *
    * @param parentType
-   *   a name of the parent relationship mapped for the join field.
+   *   a name of the parent relationship mapped for the join field
    * @param query
-   *   query you wish to run on parent documents of the parent_type field.
+   *   query you wish to run on parent documents of the `parent_type` field
    * @tparam S
    *   document for which field query is executed
    * @return
@@ -128,9 +128,9 @@ object ElasticQuery {
    * Constructs an instance of [[zio.elasticsearch.query.HasParent]] using the specified parameters.
    *
    * @param parentType
-   *   a name of the parent relationship mapped for the join field.
+   *   a name of the parent relationship mapped for the join field
    * @param query
-   *   query you wish to run on parent documents of the parent_type field.
+   *   query you wish to run on parent documents of the parent_type field
    * @return
    *   an instance of [[zio.elasticsearch.query.HasParent]] that represents the has parent query to be performed.
    */

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -130,7 +130,7 @@ object ElasticQuery {
    * @param parentType
    *   a name of the parent relationship mapped for the join field
    * @param query
-   *   query you wish to run on parent documents of the parent_type field
+   *   query you wish to run on parent documents of the `parent_type` field
    * @return
    *   an instance of [[zio.elasticsearch.query.HasParent]] that represents the has parent query to be performed.
    */

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -110,6 +110,34 @@ object ElasticQuery {
     Bool[Any](filter = queries.toList, must = Nil, mustNot = Nil, should = Nil, boost = None, minimumShouldMatch = None)
 
   /**
+   * Constructs an instance of [[zio.elasticsearch.query.HasParent]] using the specified parameters.
+   *
+   * @param parentType
+   *   a name of the parent relationship mapped for the join field.
+   * @param query
+   *   query you wish to run on parent documents of the parent_type field.
+   * @tparam S
+   *   document for which field query is executed
+   * @return
+   *   an instance of [[zio.elasticsearch.query.HasParent]] that represents the has parent query to be performed.
+   */
+  final def hasParent[S: Schema](parentType: String, query: ElasticQuery[S]): HasParentQuery[S] =
+    HasParent(parentType = parentType, query = query)
+
+  /**
+   * Constructs an instance of [[zio.elasticsearch.query.HasParent]] using the specified parameters.
+   *
+   * @param parentType
+   *   a name of the parent relationship mapped for the join field.
+   * @param query
+   *   query you wish to run on parent documents of the parent_type field.
+   * @return
+   *   an instance of [[zio.elasticsearch.query.HasParent]] that represents the has parent query to be performed.
+   */
+  final def hasParent(parentType: String, query: ElasticQuery[Any]): HasParentQuery[Any] =
+    HasParent[Any](parentType = parentType, query = query)
+
+  /**
    * Constructs an instance of [[zio.elasticsearch.query.MatchAllQuery]] used for matching all documents.
    *
    * @return

--- a/modules/library/src/main/scala/zio/elasticsearch/query/InnerHits.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/InnerHits.scala
@@ -16,6 +16,9 @@
 
 package zio.elasticsearch.query
 
+import zio.json.ast.Json
+import zio.json.ast.Json.{Num, Obj, Str}
+
 private[elasticsearch] final case class InnerHits(
   from: Option[Int] = None,
   name: Option[String] = None,
@@ -29,6 +32,11 @@ private[elasticsearch] final case class InnerHits(
 
   def size(value: Int): InnerHits =
     self.copy(size = Some(value))
+
+  def toStringJsonPair: (String, Json) =
+    "inner_hits" -> Obj(
+      List(from.map("from" -> Num(_)), size.map("size" -> Num(_)), name.map("name" -> Str(_))).flatten: _*
+    )
 }
 
 object InnerHits {

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -122,10 +122,38 @@ private[elasticsearch] final case class Match[S, A: ElasticPrimitive](field: Str
 }
 
 sealed trait HasParentQuery[S] extends ElasticQuery[S] with HasIgnoreUnmapped[HasParentQuery[S]] {
+
+  /**
+   * Sets the `score` parameter parameter for the [[HasParentQuery]].
+   *
+   * Indicates whether the relevance score of a matching parent document is aggregated into its child documents.
+   * Defaults to false.
+   *
+   * @param value
+   *   the [[scala.Boolean]] value for `score` parameter
+   * @return
+   *   a new instance of the [[HasParentQuery]] with the `score` value set.
+   */
   def withScore(value: Boolean): HasParentQuery[S]
 
+  /**
+   * Sets the `score` parameter to `false` for this [[HasParentQuery]]. Same as [[withScore]](false).
+   *
+   * @return
+   *   a new instance of the [[HasParentQuery]] with the `score` value set to `false`.
+   * @see
+   *   #withScore
+   */
   final def withScoreFalse: HasParentQuery[S] = withScore(false)
 
+  /**
+   * Sets the `score` parameter to `true` for this [[HasParentQuery]]. Same as [[withScore]](true).
+   *
+   * @return
+   *   a new instance of the [[HasParentQuery]] with the `score` value set to `true`.
+   * @see
+   *   #withScore
+   */
   final def withScoreTrue: HasParentQuery[S] = withScore(true)
 
 }

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -159,7 +159,7 @@ private[elasticsearch] final case class HasParent[S](
   def ignoreUnmapped(value: Boolean): HasParentQuery[S] =
     self.copy(ignoreUnmapped = Some(value))
 
-  override def innerHits(innerHits: InnerHits): HasParentQuery[S] =
+  def innerHits(innerHits: InnerHits): HasParentQuery[S] =
     self.copy(innerHitsField = Some(innerHits))
 
   def paramsToJson(fieldPath: Option[String]): Json =

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -124,9 +124,9 @@ private[elasticsearch] final case class Match[S, A: ElasticPrimitive](field: Str
 sealed trait HasParentQuery[S] extends ElasticQuery[S] with HasIgnoreUnmapped[HasParentQuery[S]] {
   def withScore(value: Boolean): HasParentQuery[S]
 
-  def withScoreTrue: HasParentQuery[S] = withScore(true)
+  final def withScoreFalse: HasParentQuery[S] = withScore(false)
 
-  def withScoreFalse: HasParentQuery[S] = withScore(false)
+  final def withScoreTrue: HasParentQuery[S] = withScore(true)
 
 }
 
@@ -137,10 +137,10 @@ private[elasticsearch] final case class HasParent[S](
   score: Option[Boolean] = None
 ) extends HasParentQuery[S] { self =>
 
-  override def ignoreUnmapped(value: Boolean): HasParentQuery[S] =
+  def ignoreUnmapped(value: Boolean): HasParentQuery[S] =
     self.copy(ignoreUnmapped = Some(value))
 
-  override def paramsToJson(fieldPath: Option[String]): Json =
+  def paramsToJson(fieldPath: Option[String]): Json =
     Obj(
       "has_parent" -> Obj(
         List(

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -191,7 +191,7 @@ private[elasticsearch] final case class HasParent[S](
 sealed trait MatchQuery[S] extends ElasticQuery[S] with HasBoost[MatchQuery[S]]
 
 private[elasticsearch] final case class Match[S, A: ElasticPrimitive](field: String, value: A, boost: Option[Double])
-  extends MatchQuery[S] { self =>
+    extends MatchQuery[S] { self =>
   def boost(value: Double): MatchQuery[S] =
     self.copy(boost = Some(value))
 

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -108,19 +108,6 @@ private[elasticsearch] final case class Exists[S](field: String) extends ExistsQ
     Obj("exists" -> Obj("field" -> fieldPath.foldRight(field)(_ + "." + _).toJson))
 }
 
-sealed trait MatchQuery[S] extends ElasticQuery[S] with HasBoost[MatchQuery[S]]
-
-private[elasticsearch] final case class Match[S, A: ElasticPrimitive](field: String, value: A, boost: Option[Double])
-    extends MatchQuery[S] { self =>
-  def boost(value: Double): MatchQuery[S] =
-    self.copy(boost = Some(value))
-
-  def paramsToJson(fieldPath: Option[String]): Json = {
-    val matchFields = Some(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson) ++ boost.map("boost" -> Num(_))
-    Obj("match" -> Obj(matchFields.toList: _*))
-  }
-}
-
 sealed trait HasParentQuery[S]
     extends ElasticQuery[S]
     with HasIgnoreUnmapped[HasParentQuery[S]]
@@ -199,6 +186,19 @@ private[elasticsearch] final case class HasParent[S](
    * @return
    *   a new instance of the [[ElasticQuery]] with the specified inner hits configuration.
    */
+}
+
+sealed trait MatchQuery[S] extends ElasticQuery[S] with HasBoost[MatchQuery[S]]
+
+private[elasticsearch] final case class Match[S, A: ElasticPrimitive](field: String, value: A, boost: Option[Double])
+  extends MatchQuery[S] { self =>
+  def boost(value: Double): MatchQuery[S] =
+    self.copy(boost = Some(value))
+
+  def paramsToJson(fieldPath: Option[String]): Json = {
+    val matchFields = Some(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson) ++ boost.map("boost" -> Num(_))
+    Obj("match" -> Obj(matchFields.toList: _*))
+  }
 }
 
 sealed trait MatchAllQuery extends ElasticQuery[Any] with HasBoost[MatchAllQuery]

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -1754,6 +1754,8 @@ object QueryDSLSpec extends ZIOSpecDefault {
             hasParent(parentType = "parent", query = matches("field", "value")).ignoreUnmappedFalse
           val queryWithScoreAndIgnoreUnmapped =
             hasParent(parentType = "parent", query = matches("field", "value")).withScoreTrue.ignoreUnmappedTrue
+          val queryWithInnerHits =
+            hasParent(parentType = "parent", query = matches("field", "value")).innerHits
 
           val expected =
             """
@@ -1823,10 +1825,28 @@ object QueryDSLSpec extends ZIOSpecDefault {
               |}
               |""".stripMargin
 
+          val expectedWithInnerHits =
+            """
+              |{
+              |  "query": {
+              |    "has_parent": {
+              |      "parent_type": "parent",
+              |      "query": {
+              |        "match": {
+              |         "field" : "value"
+              |        }
+              |      },
+              |      "inner_hits": {}
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
           assert(query.toJson)(equalTo(expected.toJson)) &&
           assert(queryWithScore.toJson)(equalTo(expectedWithScore.toJson)) &&
           assert(queryWithIgnoreUnmapped.toJson)(equalTo(expectedWithIgnoreUnmapped.toJson)) &&
-          assert(queryWithScoreAndIgnoreUnmapped.toJson)(equalTo(expectedWithScoreAndIgnoreUnmapped.toJson))
+          assert(queryWithScoreAndIgnoreUnmapped.toJson)(equalTo(expectedWithScoreAndIgnoreUnmapped.toJson)) &&
+          assert(queryWithInnerHits.toJson)(equalTo(expectedWithInnerHits.toJson))
         }
       )
     )

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -782,10 +782,10 @@ object QueryDSLSpec extends ZIOSpecDefault {
           )
         },
         test("successfully create HasParent query") {
-          val hasParentQuery = hasParent("parent", matchAll)
-          val hasParentQueryScoreTrue = hasParent("parent", matchAll).withScoreTrue
-          val hasParentQueryScoreFalse = hasParent("parent", matchAll).withScoreFalse
-          val hasParentQueryIgnoreUnmappedTrue = hasParent("parent", matchAll).ignoreUnmappedTrue
+          val hasParentQuery                    = hasParent("parent", matchAll)
+          val hasParentQueryScoreTrue           = hasParent("parent", matchAll).withScoreTrue
+          val hasParentQueryScoreFalse          = hasParent("parent", matchAll).withScoreFalse
+          val hasParentQueryIgnoreUnmappedTrue  = hasParent("parent", matchAll).ignoreUnmappedTrue
           val hasParentQueryIgnoreUnmappedFalse = hasParent("parent", matchAll).ignoreUnmappedFalse
 
           assert(hasParentQuery)(
@@ -799,7 +799,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
           ) && assert(hasParentQueryIgnoreUnmappedFalse)(
             equalTo(HasParent[Any](parentType = "parent", query = matchAll, ignoreUnmapped = Some(false), score = None))
           )
-        },
+        }
       ),
       suite("encoding ElasticQuery as JSON")(
         test("properly encode Match query") {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -17,6 +17,7 @@ module.exports = {
                     'overview/queries/elastic_query_contains',
                     'overview/queries/elastic_query_exists',
                     'overview/queries/elastic_query_filter',
+                    'overview/queries/elastic_query_has_parent',
                     'overview/queries/elastic_query_match_all',
                     'overview/queries/elastic_query_matches',
                     'overview/queries/elastic_query_match_phrase',


### PR DESCRIPTION
Resolves `hasParentQuery` in #91 

Summary: 
- Added has parent query
- Added tests for has parent query