### PR TITLE
Refactor ElasticQuery tests

### DIFF
--- a/modules/library/src/it/scala/zio/elasticsearch/IntegrationSpec.scala
+++ b/modules/library/src/it/scala/zio/elasticsearch/IntegrationSpec.scala
@@ -66,12 +66,14 @@ trait IntegrationSpec extends ZIOSpecDefault {
     subDocumentList <- Gen.listOfBounded(1, 3)(genTestSubDocument)
     intField        <- Gen.int(1, 2000)
     doubleField     <- Gen.double(100, 2000)
+    booleanField    <- Gen.boolean
   } yield TestDocument(
     stringField = stringField,
     dateField = dateField,
     subDocumentList = subDocumentList,
     intField = intField,
-    doubleField = doubleField
+    doubleField = doubleField,
+    booleanField = booleanField
   )
 
   def genTestSubDocument: Gen[Any, TestSubDocument] = for {

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestDSLSpec.scala
@@ -296,7 +296,7 @@ object ElasticRequestDSLSpec extends ZIOSpecDefault {
             |    "dateField": "2020-11-11",
             |    "intField": 2,
             |    "doubleField": 2.0,
-            |    "booleanField": true
+            |    "booleanField": false
             |  }
             |}
             |""".stripMargin

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestDSLSpec.scala
@@ -229,7 +229,8 @@ object ElasticRequestDSLSpec extends ZIOSpecDefault {
             subDocumentList = Nil,
             dateField = LocalDate.parse("2020-10-10"),
             intField = 1,
-            doubleField = 1.0
+            doubleField = 1.0,
+            booleanField = true
           )
         ) match { case r: Update => r.toJson }
 
@@ -247,7 +248,8 @@ object ElasticRequestDSLSpec extends ZIOSpecDefault {
             |    "subDocumentList": [],
             |    "dateField": "2020-10-10",
             |    "intField": 1,
-            |    "doubleField": 1.0
+            |    "doubleField": 1.0,
+            |    "booleanField": true
             |  }
             |}
             |""".stripMargin
@@ -263,7 +265,8 @@ object ElasticRequestDSLSpec extends ZIOSpecDefault {
             subDocumentList = Nil,
             dateField = LocalDate.parse("2020-10-10"),
             intField = 1,
-            doubleField = 1.0
+            doubleField = 1.0,
+            booleanField = true
           )
         ).orCreate[TestDocument](
           TestDocument(
@@ -271,7 +274,8 @@ object ElasticRequestDSLSpec extends ZIOSpecDefault {
             subDocumentList = Nil,
             dateField = LocalDate.parse("2020-11-11"),
             intField = 2,
-            doubleField = 2.0
+            doubleField = 2.0,
+            booleanField = false
           )
         ) match { case r: Update => r.toJson }
 
@@ -283,14 +287,16 @@ object ElasticRequestDSLSpec extends ZIOSpecDefault {
             |    "subDocumentList": [],
             |    "dateField": "2020-10-10",
             |    "intField": 1,
-            |    "doubleField": 1.0
+            |    "doubleField": 1.0,
+            |    "booleanField": true
             |  },
             |  "upsert": {
             |    "stringField": "stringField2",
             |    "subDocumentList": [],
             |    "dateField": "2020-11-11",
             |    "intField": 2,
-            |    "doubleField": 2.0
+            |    "doubleField": 2.0,
+            |    "booleanField": false
             |  }
             |}
             |""".stripMargin

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestDSLSpec.scala
@@ -296,7 +296,7 @@ object ElasticRequestDSLSpec extends ZIOSpecDefault {
             |    "dateField": "2020-11-11",
             |    "intField": 2,
             |    "doubleField": 2.0,
-            |    "booleanField": false
+            |    "booleanField": true
             |  }
             |}
             |""".stripMargin

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -1082,6 +1082,21 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(queryWithScoreAndIgnoreUnmapped.toJson)(equalTo(expectedWithScoreAndIgnoreUnmapped.toJson)) &&
           assert(queryWithInnerHits.toJson)(equalTo(expectedWithInnerHits.toJson))
         },
+        test("matches") {
+          val query = matches(field = "day_of_week", value = true)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "match": {
+              |      "day_of_week": true
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
         test("matchPhrase") {
           val querySimple      = matchPhrase(field = "stringField", value = "this is a test")
           val queryRaw         = matchPhrase(field = "stringField.raw", value = "this is a test")
@@ -1229,21 +1244,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query.toJson)(equalTo(expected.toJson)) &&
           assert(queryWithBoost.toJson)(equalTo(expectedWithBoost.toJson))
         },
-        test("properly encode Match query") {
-          val query = matches(field = "day_of_week", value = true)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "match": {
-              |      "day_of_week": true
-              |    }
-              |  }
-              |}
-              |""".stripMargin
 
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
         test("properly encode Bool Query with Filter containing `Match` leaf query") {
           val query = filter(matches(field = "day_of_week", value = "Monday"))
           val expected =
@@ -1507,7 +1508,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
 
           assert(query.toJson)(equalTo(expected.toJson))
         },
-        test("properly encode Exists Query") {
+        test("exists") {
           val query = exists(field = "day_of_week")
           val expected =
             """
@@ -1522,7 +1523,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
 
           assert(query.toJson)(equalTo(expected.toJson))
         },
-        test("properly encode MatchAll Query") {
+        test("matchAll") {
           val query = matchAll
           val expected =
             """
@@ -1535,7 +1536,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
 
           assert(query.toJson)(equalTo(expected.toJson))
         },
-        test("properly encode MatchAll Query with boost") {
+        test("matchAll (boost)") {
           val query = matchAll.boost(1.0)
           val expected =
             """
@@ -1550,7 +1551,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
 
           assert(query.toJson)(equalTo(expected.toJson))
         },
-        test("successfully create type-safe Match query using `matches` method") {
+        test("matches (type-safe)") {
           val queryString = matches(field = TestSubDocument.stringField, value = "StringField")
           val queryInt    = matches(field = TestSubDocument.intField, value = 39)
 
@@ -1984,7 +1985,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query2.toJson)(equalTo(expected23.toJson)) &&
           assert(query3.toJson)(equalTo(expected23.toJson))
         },
-        test("properly encode Bulk request body") {
+        test("bulk") {
           val bulkQuery = IndexName.make("users").map { index =>
             val nestedField = TestNestedField("NestedField", 1)
             val subDoc = TestSubDocument(

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -29,7 +29,7 @@ import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assert}
 object QueryDSLSpec extends ZIOSpecDefault {
   def spec: Spec[Environment with TestEnvironment with Scope, Any] =
     suite("Query DSL")(
-      suite("creating ElasticQuery")(
+      suite("constructing ElasticQuery")(
         suite("bool")(
           test("filter") {
             val query = filter(matches(TestDocument.stringField, "test"), matches(field = "testField", "test field"))

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -373,12 +373,12 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(queryTs)(equalTo(Exists[TestDocument](field = "intField")))
         },
         test("hasChild") {
-          val query = hasChild("child", matchAll)
+          val query                   = hasChild("child", matchAll)
           val queryWithIgnoreUnmapped = hasChild("child", matchAll).ignoreUnmappedTrue
-          val queryWithInnerHits = hasChild("child", matchAll).innerHits
-          val queryWithMaxChildren = hasChild("child", matchAll).maxChildren(5)
-          val queryWithMinChildren = hasChild("child", matchAll).minChildren(1)
-          val queryWithScoreMode = hasChild("child", matchAll).scoreMode(ScoreMode.Avg)
+          val queryWithInnerHits      = hasChild("child", matchAll).innerHits
+          val queryWithMaxChildren    = hasChild("child", matchAll).maxChildren(5)
+          val queryWithMinChildren    = hasChild("child", matchAll).minChildren(1)
+          val queryWithScoreMode      = hasChild("child", matchAll).scoreMode(ScoreMode.Avg)
           val queryWithAllParams = hasChild("child", matchAll)
             .scoreMode(ScoreMode.Avg)
             .ignoreUnmappedTrue
@@ -840,10 +840,10 @@ object QueryDSLSpec extends ZIOSpecDefault {
         test("hasChild") {
           hasChild("child", matches("field", "value"))
           val queryWithIgnoreUnmapped = hasChild("child", matches("field", "value")).ignoreUnmappedTrue
-          val queryWithInnerHits = hasChild("child", matches("field", "value")).innerHits
-          val queryWithMaxChildren = hasChild("child", matches("field", "value")).maxChildren(5)
-          val queryWithMinChildren = hasChild("child", matches("field", "value")).minChildren(1)
-          val queryWithScoreMode = hasChild("child", matches("field", "value")).scoreMode(ScoreMode.Avg)
+          val queryWithInnerHits      = hasChild("child", matches("field", "value")).innerHits
+          val queryWithMaxChildren    = hasChild("child", matches("field", "value")).maxChildren(5)
+          val queryWithMinChildren    = hasChild("child", matches("field", "value")).minChildren(1)
+          val queryWithScoreMode      = hasChild("child", matches("field", "value")).scoreMode(ScoreMode.Avg)
           val queryWithAllParams = hasChild("child", matches("field", "value"))
             .scoreMode(ScoreMode.Avg)
             .ignoreUnmappedTrue
@@ -973,11 +973,11 @@ object QueryDSLSpec extends ZIOSpecDefault {
               |""".stripMargin
 
           assert(queryWithIgnoreUnmapped.toJson)(equalTo(expectedWithIgnoreUnmapped.toJson)) &&
-            assert(queryWithInnerHits.toJson)(equalTo(expectedWithInnerHits.toJson)) &&
-            assert(queryWithMaxChildren.toJson)(equalTo(expectedWithMaxChildren.toJson)) &&
-            assert(queryWithMinChildren.toJson)(equalTo(expectedWithMinChildren.toJson)) &&
-            assert(queryWithScoreMode.toJson)(equalTo(expectedWithScoreMode.toJson)) &&
-            assert(queryWithAllParams.toJson)(equalTo(expectedFullQuery.toJson))
+          assert(queryWithInnerHits.toJson)(equalTo(expectedWithInnerHits.toJson)) &&
+          assert(queryWithMaxChildren.toJson)(equalTo(expectedWithMaxChildren.toJson)) &&
+          assert(queryWithMinChildren.toJson)(equalTo(expectedWithMinChildren.toJson)) &&
+          assert(queryWithScoreMode.toJson)(equalTo(expectedWithScoreMode.toJson)) &&
+          assert(queryWithAllParams.toJson)(equalTo(expectedFullQuery.toJson))
         },
         test("hasParent") {
           val query =
@@ -1077,10 +1077,10 @@ object QueryDSLSpec extends ZIOSpecDefault {
               |""".stripMargin
 
           assert(query.toJson)(equalTo(expected.toJson)) &&
-            assert(queryWithScore.toJson)(equalTo(expectedWithScore.toJson)) &&
-            assert(queryWithIgnoreUnmapped.toJson)(equalTo(expectedWithIgnoreUnmapped.toJson)) &&
-            assert(queryWithScoreAndIgnoreUnmapped.toJson)(equalTo(expectedWithScoreAndIgnoreUnmapped.toJson)) &&
-            assert(queryWithInnerHits.toJson)(equalTo(expectedWithInnerHits.toJson))
+          assert(queryWithScore.toJson)(equalTo(expectedWithScore.toJson)) &&
+          assert(queryWithIgnoreUnmapped.toJson)(equalTo(expectedWithIgnoreUnmapped.toJson)) &&
+          assert(queryWithScoreAndIgnoreUnmapped.toJson)(equalTo(expectedWithScoreAndIgnoreUnmapped.toJson)) &&
+          assert(queryWithInnerHits.toJson)(equalTo(expectedWithInnerHits.toJson))
         },
         test("matchPhrase") {
           val querySimple      = matchPhrase(field = "stringField", value = "this is a test")

--- a/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/QueryDSLSpec.scala
@@ -837,6 +837,324 @@ object QueryDSLSpec extends ZIOSpecDefault {
         }
       ),
       suite("encoding ElasticQuery as JSON")(
+        suite("bool")(
+          test("filter") {
+            val query = filter(matches(field = "day_of_week", value = "Monday"))
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |      "filter": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          },
+          test("filter (boost)") {
+            val query = filter(matches(field = "day_of_week", value = "Monday")).boost(1.0)
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |    "filter": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        }
+                |      ],
+                |      "boost": 1.0
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          },
+          test("must") {
+            val query = must(matches(field = "day_of_week", value = "Monday"))
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |      "must": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          },
+          test("mustNot") {
+            val query = mustNot(matches(field = "day_of_week", value = "Monday"))
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |      "must_not": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          },
+          test("should") {
+            val query = should(matches(field = "day_of_week", value = "Monday"))
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |      "should": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          },
+          test("filter + must + mustNot + should") {
+            val query = filter(matches(field = "customer_age", value = 23))
+              .must(matches(field = "customer_id", value = 1))
+              .mustNot(matches(field = "day_of_month", value = 17))
+              .should(matches(field = "day_of_week", value = "Monday"))
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |      "filter": [
+                |        {
+                |          "match": {
+                |            "customer_age": 23
+                |          }
+                |        }
+                |      ],
+                |      "must": [
+                |        {
+                |          "match": {
+                |            "customer_id": 1
+                |          }
+                |        }
+                |      ],
+                |      "must_not": [
+                |        {
+                |          "match": {
+                |            "day_of_month": 17
+                |          }
+                |        }
+                |      ],
+                |      "should": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          },
+          test("filter + must + mustNot + should (boost)") {
+            val query = filter(matches(field = "customer_age", value = 23))
+              .must(matches(field = "customer_id", value = 1))
+              .mustNot(matches(field = "day_of_month", value = 17))
+              .should(matches(field = "day_of_week", value = "Monday"))
+              .boost(1.0)
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |      "filter": [
+                |        {
+                |          "match": {
+                |            "customer_age": 23
+                |          }
+                |        }
+                |      ],
+                |      "must": [
+                |        {
+                |          "match": {
+                |            "customer_id": 1
+                |          }
+                |        }
+                |      ],
+                |      "must_not": [
+                |        {
+                |          "match": {
+                |            "day_of_month": 17
+                |          }
+                |        }
+                |      ],
+                |      "should": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        }
+                |      ],
+                |      "boost": 1.0
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          },
+          test("filter + must + mustNot + should (boost, minimumShouldMatch") {
+            val query = filter(matches(field = "customer_age", value = 23))
+              .must(matches(field = "customer_id", value = 1))
+              .mustNot(matches(field = "day_of_month", value = 17))
+              .should(
+                matches(field = "day_of_week", value = "Monday"),
+                matches(field = "day_of_week", value = "Tuesday"),
+                matches(field = "day_of_week", value = "Wednesday")
+              )
+              .boost(1.0)
+              .minimumShouldMatch(2)
+            val expected =
+              """
+                |{
+                |  "query": {
+                |    "bool": {
+                |      "filter": [
+                |        {
+                |          "match": {
+                |            "customer_age": 23
+                |          }
+                |        }
+                |      ],
+                |      "must": [
+                |        {
+                |          "match": {
+                |            "customer_id": 1
+                |          }
+                |        }
+                |      ],
+                |      "must_not": [
+                |        {
+                |          "match": {
+                |            "day_of_month": 17
+                |          }
+                |        }
+                |      ],
+                |      "should": [
+                |        {
+                |          "match": {
+                |            "day_of_week": "Monday"
+                |          }
+                |        },
+                |        {
+                |          "match": {
+                |            "day_of_week": "Tuesday"
+                |          }
+                |        },
+                |        {
+                |          "match": {
+                |            "day_of_week": "Wednesday"
+                |          }
+                |        }
+                |      ],
+                |      "boost": 1.0,
+                |      "minimum_should_match": 2
+                |    }
+                |  }
+                |}
+                |""".stripMargin
+
+            assert(query.toJson)(equalTo(expected.toJson))
+          }
+        ),
+        test("bulk") {
+          val bulkQuery = IndexName.make("users").map { index =>
+            val nestedField = TestNestedField("NestedField", 1)
+            val subDoc = TestSubDocument(
+              stringField = "StringField",
+              nestedField = nestedField,
+              intField = 100,
+              intFieldList = Nil
+            )
+            val req1 =
+              ElasticRequest
+                .create[TestSubDocument](index, DocumentId("ETux1srpww2ObCx"), subDoc.copy(intField = 65))
+                .routing(unsafeWrap(subDoc.stringField)(Routing))
+            val req2 =
+              ElasticRequest.create[TestSubDocument](index, subDoc).routing(unsafeWrap(subDoc.stringField)(Routing))
+            val req3 = ElasticRequest
+              .upsert[TestSubDocument](index, DocumentId("yMyEG8iFL5qx"), subDoc.copy(stringField = "StringField2"))
+              .routing(unsafeWrap(subDoc.stringField)(Routing))
+            val req4 =
+              ElasticRequest
+                .deleteById(index, DocumentId("1VNzFt2XUFZfXZheDc"))
+                .routing(unsafeWrap(subDoc.stringField)(Routing))
+            ElasticRequest.bulk(req1, req2, req3, req4) match {
+              case r: Bulk => Some(r.body)
+              case _       => None
+            }
+          }
+
+          val expectedBody =
+            """|{ "create" : { "_index" : "users", "_id" : "ETux1srpww2ObCx", "routing" : "StringField" } }
+               |{"stringField":"StringField","nestedField":{"stringField":"NestedField","longField":1},"intField":65,"intFieldList":[]}
+               |{ "create" : { "_index" : "users", "routing" : "StringField" } }
+               |{"stringField":"StringField","nestedField":{"stringField":"NestedField","longField":1},"intField":100,"intFieldList":[]}
+               |{ "index" : { "_index" : "users", "_id" : "yMyEG8iFL5qx", "routing" : "StringField" } }
+               |{"stringField":"StringField2","nestedField":{"stringField":"NestedField","longField":1},"intField":100,"intFieldList":[]}
+               |{ "delete" : { "_index" : "users", "_id" : "1VNzFt2XUFZfXZheDc", "routing" : "StringField" } }
+               |""".stripMargin
+
+          assert(bulkQuery)(equalTo(Validation.succeed(Some(expectedBody))))
+        },
+        test("exists") {
+          val query = exists(field = "day_of_week")
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "exists": {
+              |      "field": "day_of_week"
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
         test("hasChild") {
           hasChild("child", matches("field", "value"))
           val queryWithIgnoreUnmapped = hasChild("child", matches("field", "value")).ignoreUnmappedTrue
@@ -1082,6 +1400,34 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(queryWithScoreAndIgnoreUnmapped.toJson)(equalTo(expectedWithScoreAndIgnoreUnmapped.toJson)) &&
           assert(queryWithInnerHits.toJson)(equalTo(expectedWithInnerHits.toJson))
         },
+        test("matchAll") {
+          val query = matchAll
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "match_all": {}
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("matchAll (boost)") {
+          val query = matchAll.boost(1.0)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "match_all": {
+              |      "boost": 1.0
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
         test("matches") {
           val query = matches(field = "day_of_week", value = true)
           val expected =
@@ -1096,6 +1442,15 @@ object QueryDSLSpec extends ZIOSpecDefault {
               |""".stripMargin
 
           assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("matches (type-safe)") {
+          val queryString = matches(field = TestSubDocument.stringField, value = "StringField")
+          val queryInt    = matches(field = TestSubDocument.intField, value = 39)
+
+          assert(queryString)(
+            equalTo(Match[TestSubDocument, String](field = "stringField", value = "StringField", boost = None))
+          ) &&
+          assert(queryInt)(equalTo(Match[TestSubDocument, Int](field = "intField", value = 39, boost = None)))
         },
         test("matchPhrase") {
           val querySimple      = matchPhrase(field = "stringField", value = "this is a test")
@@ -1145,6 +1500,291 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(queryRawTs.toJson)(equalTo(queryRawExpectedJson.toJson)) &&
           assert(queryWithBoost.toJson)(equalTo(queryWithBoostExpectedJson.toJson)) &&
           assert(queryWithBoostTs.toJson)(equalTo(queryWithBoostExpectedJson.toJson))
+        },
+        test("nested") {
+          val query = nested(path = "customer", query = matchAll)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "nested": {
+              |      "path": "customer",
+              |      "query": {
+              |        "match_all": {}
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("nested 2") {
+          val query = nested(path = "customer", query = nested(path = "items", query = term("type", "clothing")))
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "nested": {
+              |      "path": "customer",
+              |      "query": {
+              |        "nested": {
+              |          "path": "customer.items",
+              |          "query": {
+              |            "term": {
+              |              "customer.items.type": {
+              |                "value": "clothing"
+              |              }
+              |            }
+              |          }
+              |        }
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("nested (scoreMode)") {
+          val query = nested(path = "customer", query = matchAll).scoreMode(ScoreMode.Avg)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "nested": {
+              |      "path": "customer",
+              |      "query": {
+              |        "match_all": {}
+              |      },
+              |      "score_mode": "avg"
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("nested (ignoreUnmapped)") {
+          val query = nested(path = "customer", query = matchAll).ignoreUnmappedFalse
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "nested": {
+              |      "path": "customer",
+              |      "query": {
+              |        "match_all": {}
+              |      },
+              |      "ignore_unmapped": false
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("nested (scoreMode, ignoreUnmapped)") {
+          val query = nested(path = "customer", query = matchAll).scoreMode(ScoreMode.Avg).ignoreUnmappedFalse
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "nested": {
+              |      "path": "customer",
+              |      "query": {
+              |        "match_all": {}
+              |      },
+              |      "score_mode": "avg",
+              |      "ignore_unmapped": false
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("nested (empty innerHits)") {
+          val query = nested(path = "customer", query = matchAll).innerHits
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "nested": {
+              |      "path": "customer",
+              |      "query": {
+              |        "match_all": {}
+              |      },
+              |      "inner_hits": {}
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("nested (innerHits)") {
+          val query = nested(path = "customer", query = matchAll).innerHits(
+            InnerHits.from(0).size(3).name("name")
+          )
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "nested": {
+              |      "path": "customer",
+              |      "query": {
+              |        "match_all": {}
+              |      },
+              |      "inner_hits": {
+              |        "from": 0,
+              |        "size": 3,
+              |        "name": "name"
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range") {
+          val query = range(field = "field")
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "field": {
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range (boost)") {
+          val query = range(field = "field").boost(1.0)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "field": {
+              |      },
+              |      "boost": 1.0
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range (lower bound)") {
+          val query = range(field = "customer_age").gt(23)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "customer_age": {
+              |        "gt": 23
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range (upper bound)") {
+          val query = range(field = "customer_age").lt(23)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "customer_age": {
+              |        "lt": 23
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range (inclusive lower bound)") {
+          val query = range(field = "expiry_date").gte("now")
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "expiry_date": {
+              |        "gte": "now"
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range (inclusive upper bound") {
+          val query = range(field = "customer_age").lte(100L)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "customer_age": {
+              |        "lte": 100
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range (bounds)") {
+          val query = range(field = "customer_age").gte(10).lt(100)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "customer_age": {
+              |        "gte": 10,
+              |        "lt": 100
+              |      }
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
+        },
+        test("range (bounds, boost)") {
+          val query = range(field = "customer_age").gte(10).lt(100).boost(1.0)
+          val expected =
+            """
+              |{
+              |  "query": {
+              |    "range": {
+              |      "customer_age": {
+              |        "gte": 10,
+              |        "lt": 100
+              |      },
+              |      "boost": 1.0
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson)(equalTo(expected.toJson))
         },
         test("term") {
           val query                    = term(field = TestDocument.stringField, value = "test")
@@ -1244,608 +1884,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query.toJson)(equalTo(expected.toJson)) &&
           assert(queryWithBoost.toJson)(equalTo(expectedWithBoost.toJson))
         },
-
-        test("properly encode Bool Query with Filter containing `Match` leaf query") {
-          val query = filter(matches(field = "day_of_week", value = "Monday"))
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |      "filter": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        }
-              |      ]
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Bool Query with Filter containing `Match` leaf query with boost") {
-          val query = filter(matches(field = "day_of_week", value = "Monday")).boost(1.0)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |    "filter": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        }
-              |      ],
-              |      "boost": 1.0
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Bool Query with Must containing `Match` leaf query") {
-          val query = must(matches(field = "day_of_week", value = "Monday"))
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |      "must": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        }
-              |      ]
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Bool Query with MustNot containing `Match` leaf query") {
-          val query = mustNot(matches(field = "day_of_week", value = "Monday"))
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |      "must_not": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        }
-              |      ]
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Bool Query with Should containing `Match` leaf query") {
-          val query = should(matches(field = "day_of_week", value = "Monday"))
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |      "should": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        }
-              |      ]
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Bool Query with Filter, Must, MustNot and Should containing `Match` leaf query") {
-          val query = filter(matches(field = "customer_age", value = 23))
-            .must(matches(field = "customer_id", value = 1))
-            .mustNot(matches(field = "day_of_month", value = 17))
-            .should(matches(field = "day_of_week", value = "Monday"))
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |      "filter": [
-              |        {
-              |          "match": {
-              |            "customer_age": 23
-              |          }
-              |        }
-              |      ],
-              |      "must": [
-              |        {
-              |          "match": {
-              |            "customer_id": 1
-              |          }
-              |        }
-              |      ],
-              |      "must_not": [
-              |        {
-              |          "match": {
-              |            "day_of_month": 17
-              |          }
-              |        }
-              |      ],
-              |      "should": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        }
-              |      ]
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Bool Query with Filter, Must, MustNot and Should containing `Match` leaf query, boost") {
-          val query = filter(matches(field = "customer_age", value = 23))
-            .must(matches(field = "customer_id", value = 1))
-            .mustNot(matches(field = "day_of_month", value = 17))
-            .should(matches(field = "day_of_week", value = "Monday"))
-            .boost(1.0)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |      "filter": [
-              |        {
-              |          "match": {
-              |            "customer_age": 23
-              |          }
-              |        }
-              |      ],
-              |      "must": [
-              |        {
-              |          "match": {
-              |            "customer_id": 1
-              |          }
-              |        }
-              |      ],
-              |      "must_not": [
-              |        {
-              |          "match": {
-              |            "day_of_month": 17
-              |          }
-              |        }
-              |      ],
-              |      "should": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        }
-              |      ],
-              |      "boost": 1.0
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test(
-          "properly encode Bool Query with Filter, Must, MustNot and Should containing `Match` leaf query and with boost, minimumShouldMatch"
-        ) {
-          val query = filter(matches(field = "customer_age", value = 23))
-            .must(matches(field = "customer_id", value = 1))
-            .mustNot(matches(field = "day_of_month", value = 17))
-            .should(
-              matches(field = "day_of_week", value = "Monday"),
-              matches(field = "day_of_week", value = "Tuesday"),
-              matches(field = "day_of_week", value = "Wednesday")
-            )
-            .boost(1.0)
-            .minimumShouldMatch(2)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "bool": {
-              |      "filter": [
-              |        {
-              |          "match": {
-              |            "customer_age": 23
-              |          }
-              |        }
-              |      ],
-              |      "must": [
-              |        {
-              |          "match": {
-              |            "customer_id": 1
-              |          }
-              |        }
-              |      ],
-              |      "must_not": [
-              |        {
-              |          "match": {
-              |            "day_of_month": 17
-              |          }
-              |        }
-              |      ],
-              |      "should": [
-              |        {
-              |          "match": {
-              |            "day_of_week": "Monday"
-              |          }
-              |        },
-              |        {
-              |          "match": {
-              |            "day_of_week": "Tuesday"
-              |          }
-              |        },
-              |        {
-              |          "match": {
-              |            "day_of_week": "Wednesday"
-              |          }
-              |        }
-              |      ],
-              |      "boost": 1.0,
-              |      "minimum_should_match": 2
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("exists") {
-          val query = exists(field = "day_of_week")
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "exists": {
-              |      "field": "day_of_week"
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("matchAll") {
-          val query = matchAll
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "match_all": {}
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("matchAll (boost)") {
-          val query = matchAll.boost(1.0)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "match_all": {
-              |      "boost": 1.0
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("matches (type-safe)") {
-          val queryString = matches(field = TestSubDocument.stringField, value = "StringField")
-          val queryInt    = matches(field = TestSubDocument.intField, value = 39)
-
-          assert(queryString)(
-            equalTo(Match[TestSubDocument, String](field = "stringField", value = "StringField", boost = None))
-          ) &&
-          assert(queryInt)(equalTo(Match[TestSubDocument, Int](field = "intField", value = 39, boost = None)))
-        },
-        test("properly encode Nested Query with MatchAll Query") {
-          val query = nested(path = "customer", query = matchAll)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "nested": {
-              |      "path": "customer",
-              |      "query": {
-              |        "match_all": {}
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode nested Nested Queries with Term Query") {
-          val query = nested(path = "customer", query = nested(path = "items", query = term("type", "clothing")))
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "nested": {
-              |      "path": "customer",
-              |      "query": {
-              |        "nested": {
-              |          "path": "customer.items",
-              |          "query": {
-              |            "term": {
-              |              "customer.items.type": {
-              |                "value": "clothing"
-              |              }
-              |            }
-              |          }
-              |        }
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Nested Query with MatchAll Query and score_mode") {
-          val query = nested(path = "customer", query = matchAll).scoreMode(ScoreMode.Avg)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "nested": {
-              |      "path": "customer",
-              |      "query": {
-              |        "match_all": {}
-              |      },
-              |      "score_mode": "avg"
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Nested Query with MatchAll Query and ignore_unmapped") {
-          val query = nested(path = "customer", query = matchAll).ignoreUnmappedFalse
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "nested": {
-              |      "path": "customer",
-              |      "query": {
-              |        "match_all": {}
-              |      },
-              |      "ignore_unmapped": false
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Nested Query with MatchAll Query, score_mode and ignore_unmapped") {
-          val query = nested(path = "customer", query = matchAll).scoreMode(ScoreMode.Avg).ignoreUnmappedFalse
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "nested": {
-              |      "path": "customer",
-              |      "query": {
-              |        "match_all": {}
-              |      },
-              |      "score_mode": "avg",
-              |      "ignore_unmapped": false
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Nested Query with MatchAll Query and inner hits with empty body") {
-          val query = nested(path = "customer", query = matchAll).innerHits
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "nested": {
-              |      "path": "customer",
-              |      "query": {
-              |        "match_all": {}
-              |      },
-              |      "inner_hits": {}
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Nested Query with MatchAll Query and inner hits with from, size and name fields") {
-          val query = nested(path = "customer", query = matchAll).innerHits(
-            InnerHits.from(0).size(3).name("name")
-          )
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "nested": {
-              |      "path": "customer",
-              |      "query": {
-              |        "match_all": {}
-              |      },
-              |      "inner_hits": {
-              |        "from": 0,
-              |        "size": 3,
-              |        "name": "name"
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Unbounded Range Query") {
-          val query = range(field = "field")
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "field": {
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Unbounded Range Query with boost") {
-          val query = range(field = "field").boost(1.0)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "field": {
-              |      },
-              |      "boost": 1.0
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Range Query with Lower Bound") {
-          val query = range(field = "customer_age").gt(23)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "customer_age": {
-              |        "gt": 23
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Range Query with Upper Bound") {
-          val query = range(field = "customer_age").lt(23)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "customer_age": {
-              |        "lt": 23
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Range Query with Inclusive Lower Bound") {
-          val query = range(field = "expiry_date").gte("now")
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "expiry_date": {
-              |        "gte": "now"
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Range Query with inclusive Upper Bound") {
-          val query = range(field = "customer_age").lte(100L)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "customer_age": {
-              |        "lte": 100
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Range Query with both Upper and Lower Bound") {
-          val query = range(field = "customer_age").gte(10).lt(100)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "customer_age": {
-              |        "gte": 10,
-              |        "lt": 100
-              |      }
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Range Query with both Upper and Lower Bound with boost") {
-          val query = range(field = "customer_age").gte(10).lt(100).boost(1.0)
-          val expected =
-            """
-              |{
-              |  "query": {
-              |    "range": {
-              |      "customer_age": {
-              |        "gte": 10,
-              |        "lt": 100
-              |      },
-              |      "boost": 1.0
-              |    }
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson)(equalTo(expected.toJson))
-        },
-        test("properly encode Wildcard query") {
+        test("wildcard") {
           val query1 = contains(field = "day_of_week", value = "M")
           val query2 = startsWith(field = "day_of_week", value = "M")
           val query3 = wildcard(field = "day_of_week", value = "M*")
@@ -1878,7 +1917,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query2.toJson)(equalTo(expected23.toJson)) &&
           assert(query3.toJson)(equalTo(expected23.toJson))
         },
-        test("properly encode Wildcard query with boost") {
+        test("wildcard (boost)") {
           val query1 = contains(field = "day_of_week", value = "M").boost(1.0)
           val query2 = startsWith(field = "day_of_week", value = "M").boost(1.0)
           val query3 = wildcard(field = "day_of_week", value = "M*").boost(1.0)
@@ -1913,7 +1952,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query2.toJson)(equalTo(expected23.toJson)) &&
           assert(query3.toJson)(equalTo(expected23.toJson))
         },
-        test("properly encode case insensitive Wildcard query") {
+        test("wildcard (case insensitive)") {
           val query1 = contains(field = "day_of_week", value = "M").caseInsensitiveTrue
           val query2 = startsWith(field = "day_of_week", value = "M").caseInsensitiveTrue
           val query3 = wildcard(field = "day_of_week", value = "M*").caseInsensitiveTrue
@@ -1948,7 +1987,7 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query2.toJson)(equalTo(expected23.toJson)) &&
           assert(query3.toJson)(equalTo(expected23.toJson))
         },
-        test("properly encode case insensitive Wildcard query with boost") {
+        test("wildcard (case insensitive, boost)") {
           val query1 = contains(field = "day_of_week", value = "M").boost(1.0).caseInsensitiveTrue
           val query2 = startsWith(field = "day_of_week", value = "M").boost(1.0).caseInsensitiveTrue
           val query3 = wildcard(field = "day_of_week", value = "M*").boost(1.0).caseInsensitiveTrue
@@ -1984,46 +2023,6 @@ object QueryDSLSpec extends ZIOSpecDefault {
           assert(query1.toJson)(equalTo(expected1.toJson)) &&
           assert(query2.toJson)(equalTo(expected23.toJson)) &&
           assert(query3.toJson)(equalTo(expected23.toJson))
-        },
-        test("bulk") {
-          val bulkQuery = IndexName.make("users").map { index =>
-            val nestedField = TestNestedField("NestedField", 1)
-            val subDoc = TestSubDocument(
-              stringField = "StringField",
-              nestedField = nestedField,
-              intField = 100,
-              intFieldList = Nil
-            )
-            val req1 =
-              ElasticRequest
-                .create[TestSubDocument](index, DocumentId("ETux1srpww2ObCx"), subDoc.copy(intField = 65))
-                .routing(unsafeWrap(subDoc.stringField)(Routing))
-            val req2 =
-              ElasticRequest.create[TestSubDocument](index, subDoc).routing(unsafeWrap(subDoc.stringField)(Routing))
-            val req3 = ElasticRequest
-              .upsert[TestSubDocument](index, DocumentId("yMyEG8iFL5qx"), subDoc.copy(stringField = "StringField2"))
-              .routing(unsafeWrap(subDoc.stringField)(Routing))
-            val req4 =
-              ElasticRequest
-                .deleteById(index, DocumentId("1VNzFt2XUFZfXZheDc"))
-                .routing(unsafeWrap(subDoc.stringField)(Routing))
-            ElasticRequest.bulk(req1, req2, req3, req4) match {
-              case r: Bulk => Some(r.body)
-              case _       => None
-            }
-          }
-
-          val expectedBody =
-            """|{ "create" : { "_index" : "users", "_id" : "ETux1srpww2ObCx", "routing" : "StringField" } }
-               |{"stringField":"StringField","nestedField":{"stringField":"NestedField","longField":1},"intField":65,"intFieldList":[]}
-               |{ "create" : { "_index" : "users", "routing" : "StringField" } }
-               |{"stringField":"StringField","nestedField":{"stringField":"NestedField","longField":1},"intField":100,"intFieldList":[]}
-               |{ "index" : { "_index" : "users", "_id" : "yMyEG8iFL5qx", "routing" : "StringField" } }
-               |{"stringField":"StringField2","nestedField":{"stringField":"NestedField","longField":1},"intField":100,"intFieldList":[]}
-               |{ "delete" : { "_index" : "users", "_id" : "1VNzFt2XUFZfXZheDc", "routing" : "StringField" } }
-               |""".stripMargin
-
-          assert(bulkQuery)(equalTo(Validation.succeed(Some(expectedBody))))
         }
       )
     )

--- a/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
@@ -40,7 +40,8 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
       subDocumentList = List(subDoc),
       dateField = LocalDate.parse("2020-10-11"),
       intField = 10,
-      doubleField = 10.0
+      doubleField = 10.0,
+      booleanField = true
     )
 
   val secondDoc: TestDocument =
@@ -49,7 +50,8 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
       subDocumentList = Nil,
       dateField = LocalDate.parse("2020-12-12"),
       intField = 12,
-      doubleField = 12.0
+      doubleField = 12.0,
+      booleanField = false
     )
 
   private val url = "http://localhost:9200"

--- a/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
@@ -202,7 +202,8 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
         |    ],
         |    "dateField": "2020-10-11",
         |    "intField": 10,
-        |    "doubleField": 10.0
+        |    "doubleField": 10.0,
+        |    "booleanField": true
         |  }
         |}""".stripMargin,
       StatusCode.Ok
@@ -249,7 +250,8 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
         |          ],
         |          "dateField": "2020-10-11",
         |          "intField": 10,
-        |          "doubleField": 10.0
+        |          "doubleField": 10.0,
+        |          "booleanField": false
         |        }
         |      }
         |    ]
@@ -299,7 +301,8 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
         |          ],
         |          "dateField": "2020-10-11",
         |          "intField": 10,
-        |          "doubleField": 10.0
+        |          "doubleField": 10.0,
+        |          "booleanField": true
         |        }
         |      }
         |    ]

--- a/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
@@ -41,7 +41,7 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
       dateField = LocalDate.parse("2020-10-11"),
       intField = 10,
       doubleField = 10.0,
-      booleanField = true
+      booleanField = false
     )
 
   val secondDoc: TestDocument =

--- a/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/SttpBackendStubSpec.scala
@@ -41,7 +41,7 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
       dateField = LocalDate.parse("2020-10-11"),
       intField = 10,
       doubleField = 10.0,
-      booleanField = false
+      booleanField = true
     )
 
   val secondDoc: TestDocument =
@@ -51,7 +51,7 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
       dateField = LocalDate.parse("2020-12-12"),
       intField = 12,
       doubleField = 12.0,
-      booleanField = false
+      booleanField = true
     )
 
   private val url = "http://localhost:9200"
@@ -251,7 +251,7 @@ trait SttpBackendStubSpec extends ZIOSpecDefault {
         |          "dateField": "2020-10-11",
         |          "intField": 10,
         |          "doubleField": 10.0,
-        |          "booleanField": false
+        |          "booleanField": true
         |        }
         |      }
         |    ]

--- a/modules/library/src/test/scala/zio/elasticsearch/domain/TestDocument.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/domain/TestDocument.scala
@@ -10,12 +10,14 @@ final case class TestDocument(
   subDocumentList: List[TestSubDocument],
   dateField: LocalDate,
   intField: Int,
-  doubleField: Double
+  doubleField: Double,
+  booleanField: Boolean
 )
 
 object TestDocument {
-  implicit val schema: Schema.CaseClass5[String, List[TestSubDocument], LocalDate, Int, Double, TestDocument] =
+  implicit val schema: Schema.CaseClass6[String, List[TestSubDocument], LocalDate, Int, Double, Boolean, TestDocument] =
     DeriveSchema.gen[TestDocument]
 
-  val (stringField, subDocumentList, dateField, intField, doubleField) = schema.makeAccessors(FieldAccessorBuilder)
+  val (stringField, subDocumentList, dateField, intField, doubleField, booleanField) =
+    schema.makeAccessors(FieldAccessorBuilder)
 }


### PR DESCRIPTION
### Summary:

- Renamed `QueryDSLSpec` to `ElasticQuerySpec`. 
- Group all tests to related query - `bool`, `matches`, `matchAll`, etc. 
- Use simpler naming in tests.