### PR TITLE
Refactor core and add missing scaladoc

### DIFF
--- a/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
@@ -77,8 +77,7 @@ private[elasticsearch] final case class BucketSort(
   sortBy: Chunk[Sort],
   from: Option[Int],
   size: Option[Int]
-) extends BucketSortAggregation {
-  self =>
+) extends BucketSortAggregation { self =>
   def from(value: Int): BucketSortAggregation =
     self.copy(from = Some(value))
 
@@ -141,6 +140,15 @@ private[elasticsearch] final case class Max(name: String, field: String, missing
 }
 
 sealed trait MultipleAggregations extends ElasticAggregation with WithAgg {
+
+  /**
+   * Sets the aggregations for the [[zio.elasticsearch.aggregation.MultipleAggregations]].
+   *
+   * @param aggregations
+   *   the aggregations to be set
+   * @return
+   *   an instance of the [[zio.elasticsearch.aggregation.MultipleAggregations]] with the specified aggregations.
+   */
   def aggregations(aggregations: SingleElasticAggregation*): MultipleAggregations
 }
 
@@ -149,11 +157,11 @@ private[elasticsearch] final case class Multiple(aggregations: Chunk[SingleElast
   def aggregations(aggregations: SingleElasticAggregation*): MultipleAggregations =
     self.copy(aggregations = self.aggregations ++ aggregations)
 
-  private[elasticsearch] def toJson: Json =
-    aggregations.map(_.toJson).reduce(_ merge _)
-
   def withAgg(agg: SingleElasticAggregation): MultipleAggregations =
     self.copy(aggregations = agg +: aggregations)
+
+  private[elasticsearch] def toJson: Json =
+    aggregations.map(_.toJson).reduce(_ merge _)
 }
 
 sealed trait TermsAggregation

--- a/modules/library/src/main/scala/zio/elasticsearch/query/sort/Sort.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/sort/Sort.scala
@@ -34,9 +34,7 @@ sealed trait SortByField
     with HasMode[SortByField]
     with HasNumericType[SortByField]
     with HasOrder[SortByField]
-    with HasUnmappedType[SortByField] {
-  def toJson: Json
-}
+    with HasUnmappedType[SortByField]
 
 object SortByField {
 
@@ -129,7 +127,10 @@ private[elasticsearch] final case class SortByFieldOptions(
   def order(value: SortOrder): SortByField =
     self.copy(order = Some(value))
 
-  def toJson: Json = {
+  def unmappedType(value: String): SortByField =
+    self.copy(unmappedType = Some(value))
+
+  private[elasticsearch] def toJson: Json = {
     val allParams = Chunk(
       self.order.map(order => "order" -> order.toString.toJson),
       self.format.map(format => "format" -> format.toJson),
@@ -141,9 +142,6 @@ private[elasticsearch] final case class SortByFieldOptions(
 
     if (allParams.isEmpty) self.field.toJson else Obj(self.field -> Obj(allParams))
   }
-
-  def unmappedType(value: String): SortByField =
-    self.copy(unmappedType = Some(value))
 }
 
 sealed trait SortByScript extends Sort with HasMode[SortByScript] with HasOrder[SortByScript]
@@ -160,7 +158,7 @@ private[elasticsearch] final case class SortByScriptOptions(
   def order(value: SortOrder): SortByScript =
     self.copy(order = Some(value))
 
-  def toJson: Json =
+  private[elasticsearch] def toJson: Json =
     Obj(
       "_script" -> Obj(
         Chunk(

--- a/modules/library/src/main/scala/zio/elasticsearch/request/options/HasHighlights.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/request/options/HasHighlights.scala
@@ -1,0 +1,16 @@
+package zio.elasticsearch.request.options
+
+import zio.elasticsearch.highlights.Highlights
+
+private[elasticsearch] trait HasHighlights[R <: HasHighlights[R]] {
+
+  /**
+   * Sets the [[zio.elasticsearch.highlights.Highlights]] for the [[zio.elasticsearch.ElasticRequest]].
+   *
+   * @param value
+   *   the [[zio.elasticsearch.highlights.Highlights]] to be set
+   * @return
+   *   an instance of the [[zio.elasticsearch.ElasticRequest]] enriched with the highlights.
+   */
+  def highlights(value: Highlights): R
+}

--- a/modules/library/src/main/scala/zio/elasticsearch/request/options/HasHighlights.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/request/options/HasHighlights.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LambdaWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.elasticsearch.request.options
 
 import zio.elasticsearch.highlights.Highlights

--- a/modules/library/src/main/scala/zio/elasticsearch/request/options/HasSearchAfter.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/request/options/HasSearchAfter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LambdaWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.elasticsearch.request.options
 
 import zio.json.ast.Json

--- a/modules/library/src/main/scala/zio/elasticsearch/request/options/HasSearchAfter.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/request/options/HasSearchAfter.scala
@@ -1,0 +1,16 @@
+package zio.elasticsearch.request.options
+
+import zio.json.ast.Json
+
+private[elasticsearch] trait HasSearchAfter[R <: HasSearchAfter[R]] {
+
+  /**
+   * Sets the `search_after` parameter for the [[zio.elasticsearch.ElasticRequest]].
+   *
+   * @param value
+   *   the JSON value to be set as the `search_after` parameter
+   * @return
+   *   an instance of a [[zio.elasticsearch.ElasticRequest]] enriched with the `search_after` parameter.
+   */
+  def searchAfter(value: Json): R
+}

--- a/modules/library/src/main/scala/zio/elasticsearch/request/options/HasSourceFiltering.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/request/options/HasSourceFiltering.scala
@@ -17,9 +17,27 @@
 package zio.elasticsearch.request.options
 
 import zio.Chunk
+import zio.elasticsearch.Field
 import zio.schema.Schema
 
 private[elasticsearch] trait HasSourceFiltering[R <: HasSourceFiltering[R]] {
+
+  /**
+   * Specifies one or more type-safe fields to be excluded in the response of a
+   * [[zio.elasticsearch.ElasticRequest.SearchRequest]] or a
+   * [[zio.elasticsearch.ElasticRequest.SearchAndAggregateRequest]].
+   *
+   * @param field
+   *   a type-safe field to be excluded
+   * @param fields
+   *   type-safe fields to be excluded
+   * @tparam S
+   *   document which fields are excluded
+   * @return
+   *   an instance of a [[zio.elasticsearch.ElasticRequest.SearchRequest]] or a
+   *   [[zio.elasticsearch.ElasticRequest.SearchAndAggregateRequest]] with specified fields to be excluded.
+   */
+  def excludes[S](field: Field[S, _], fields: Field[S, _]*): R
 
   /**
    * Specifies one or more fields to be excluded in the response of a [[zio.elasticsearch.ElasticRequest.SearchRequest]]
@@ -34,6 +52,21 @@ private[elasticsearch] trait HasSourceFiltering[R <: HasSourceFiltering[R]] {
    *   [[zio.elasticsearch.ElasticRequest.SearchAndAggregateRequest]] with specified fields to be excluded.
    */
   def excludes(field: String, fields: String*): R
+
+  /**
+   * Specifies one or more type-safe fields to be included in the response of a
+   * [[zio.elasticsearch.ElasticRequest.SearchRequest]] or a
+   * [[zio.elasticsearch.ElasticRequest.SearchAndAggregateRequest]].
+   *
+   * @param field
+   *   a type-safe field to be included
+   * @param fields
+   *   type-safe fields to be included
+   * @return
+   *   an instance of a [[zio.elasticsearch.ElasticRequest.SearchRequest]] or a
+   *   [[zio.elasticsearch.ElasticRequest.SearchAndAggregateRequest]] with specified fields to be included.
+   */
+  def includes[S](field: Field[S, _], fields: Field[S, _]*): R
 
   /**
    * Specifies one or more fields to be included in the response of a [[zio.elasticsearch.ElasticRequest.SearchRequest]]

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticRequestSpec.scala
@@ -284,13 +284,13 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           assert(searchRequest)(
             equalTo(
               Search(
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -299,6 +299,8 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithSort)(
             equalTo(
               Search(
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
                 sortBy = Chunk(
@@ -312,10 +314,8 @@ object ElasticRequestSpec extends ZIOSpecDefault {
                     unmappedType = None
                   )
                 ),
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -324,13 +324,13 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithSourceFiltering)(
             equalTo(
               Search(
+                excluded = Chunk("booleanField"),
+                included = Chunk("stringField", "doubleField"),
                 index = Index,
                 query = Query,
                 sortBy = Chunk.empty,
-                excluded = Some(Chunk("booleanField")),
                 from = None,
                 highlights = None,
-                included = Some(Chunk("stringField", "doubleField")),
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -339,13 +339,13 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithFrom)(
             equalTo(
               Search(
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = Some(5),
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -354,15 +354,15 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithHighlights)(
             equalTo(
               Search(
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = Some(
                   Highlights(fields = Chunk(HighlightField(field = "intField", config = Map.empty)), config = Map.empty)
                 ),
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -371,13 +371,13 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithRouting)(
             equalTo(
               Search(
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = Some(RoutingValue),
                 searchAfter = None,
                 size = None
@@ -386,13 +386,13 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithSearchAfter)(
             equalTo(
               Search(
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = Some(Arr(Str("12345"))),
                 size = None
@@ -401,13 +401,13 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithSize)(
             equalTo(
               Search(
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = Some(5)
@@ -416,6 +416,8 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchRequestWithAllParams)(
             equalTo(
               Search(
+                excluded = Chunk("booleanField"),
+                included = Chunk("stringField", "doubleField"),
                 index = Index,
                 query = Query,
                 sortBy = Chunk(
@@ -429,12 +431,10 @@ object ElasticRequestSpec extends ZIOSpecDefault {
                     unmappedType = None
                   )
                 ),
-                excluded = Some(Chunk("booleanField")),
                 from = Some(5),
                 highlights = Some(
                   Highlights(fields = Chunk(HighlightField(field = "intField", config = Map.empty)), config = Map.empty)
                 ),
-                included = Some(Chunk("stringField", "doubleField")),
                 routing = Some(RoutingValue),
                 searchAfter = Some(Arr(Str("12345"))),
                 size = Some(5)
@@ -473,14 +473,14 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           assert(searchAndAggRequest)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -489,9 +489,11 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithSort)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk(
                   SortByFieldOptions(
                     field = "intField",
@@ -503,10 +505,8 @@ object ElasticRequestSpec extends ZIOSpecDefault {
                     unmappedType = None
                   )
                 ),
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -515,14 +515,14 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithSourceFiltering)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk("booleanField"),
+                included = Chunk("stringField", "doubleField"),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk.empty,
-                excluded = Some(Chunk("booleanField")),
                 from = None,
                 highlights = None,
-                included = Some(Chunk("stringField", "doubleField")),
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -531,14 +531,14 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithFrom)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = Some(5),
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -547,16 +547,16 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithHighlights)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = Some(
                   Highlights(fields = Chunk(HighlightField(field = "intField", config = Map.empty)), config = Map.empty)
                 ),
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = None
@@ -565,14 +565,14 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithRouting)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = Some(RoutingValue),
                 searchAfter = None,
                 size = None
@@ -581,14 +581,14 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithSearchAfter)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = Some(Arr(Str("12345"))),
                 size = None
@@ -597,14 +597,14 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithSize)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk(),
+                included = Chunk(),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk.empty,
-                excluded = None,
                 from = None,
                 highlights = None,
-                included = None,
                 routing = None,
                 searchAfter = None,
                 size = Some(5)
@@ -613,9 +613,11 @@ object ElasticRequestSpec extends ZIOSpecDefault {
           ) && assert(searchAndAggRequestWithAllParams)(
             equalTo(
               SearchAndAggregate(
+                aggregation = MaxAggregation,
+                excluded = Chunk("booleanField"),
+                included = Chunk("stringField", "doubleField"),
                 index = Index,
                 query = Query,
-                aggregation = MaxAggregation,
                 sortBy = Chunk(
                   SortByFieldOptions(
                     field = "intField",
@@ -627,12 +629,10 @@ object ElasticRequestSpec extends ZIOSpecDefault {
                     unmappedType = None
                   )
                 ),
-                excluded = Some(Chunk("booleanField")),
                 from = Some(5),
                 highlights = Some(
                   Highlights(fields = Chunk(HighlightField(field = "intField", config = Map.empty)), config = Map.empty)
                 ),
-                included = Some(Chunk("stringField", "doubleField")),
                 routing = Some(RoutingValue),
                 searchAfter = Some(Arr(Str("12345"))),
                 size = Some(5)


### PR DESCRIPTION
1. Added missing `scaladoc` for public methods
2. Refactor source filtering in ElasticRequest and add type-safety
3. Make toJson method private[elasticsearch]
4. Move certain methods from requests to separated traits (search after and highlights)
5. Other small changes