### PR TITLE
(dsl): Support `geoShape` query

### DIFF
--- a/modules/library/src/it/scala/zio/elasticsearch/IntegrationSpec.scala
+++ b/modules/library/src/it/scala/zio/elasticsearch/IntegrationSpec.scala
@@ -51,6 +51,8 @@ trait IntegrationSpec extends ZIOSpecDefault {
 
   val geoDistanceIndex: IndexName = IndexName("geo-distance-index")
 
+  val geoShapeIndex: IndexName = IndexName("geo-shape-index")
+
   val prepareElasticsearchIndexForTests: TestAspect[Nothing, Any, Throwable, Any] = beforeAll((for {
     _ <- Executor.execute(ElasticRequest.createIndex(index))
     _ <- Executor.execute(ElasticRequest.deleteByQuery(index, matchAll).refreshTrue)

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -18,6 +18,7 @@ package zio.elasticsearch
 
 import zio.Chunk
 import zio.elasticsearch.ElasticPrimitive.ElasticPrimitive
+import zio.elasticsearch.data.GeoShape
 import zio.elasticsearch.query._
 import zio.elasticsearch.script.Script
 import zio.schema.Schema
@@ -263,6 +264,50 @@ object ElasticQuery {
       distanceType = None,
       queryName = None,
       validationMethod = None
+    )
+
+  /**
+   * Constructs a type-safe instance of [[zio.elasticsearch.query.GeoShapeInlineQuery]] using the specified parameters.
+   *
+   * @param field
+   *   the type-safe field for which query is specified for
+   * @param shape
+   *   the shape upon which the spatial relation is defined
+   * @tparam S
+   *   document for which field query is executed
+   * @return
+   *   an instance of [[zio.elasticsearch.query.GeoShapeInlineQuery]] that represents `geo_shape` query to be performed.
+   */
+  final def geoShapeInline[S](
+    field: Field[S, _],
+    shape: GeoShape
+  ): GeoShapeInlineQuery[S] =
+    GeoShapeInline(
+      field = field.toString,
+      shape = shape,
+      relation = None
+    )
+
+  /**
+   * Constructs a type-safe instance of [[zio.elasticsearch.query.GeoShapeInlineQuery]] using the specified parameters.
+   *
+   * @param field
+   *   the type-safe field for which query is specified for
+   * @param shape
+   *   the shape upon which the spatial relation is defined
+   * @tparam S
+   *   document for which field query is executed
+   * @return
+   *   an instance of [[zio.elasticsearch.query.GeoShapeInlineQuery]] that represents `geo_shape` query to be performed.
+   */
+  final def geoShapeInline[S](
+    field: String,
+    shape: GeoShape
+  ): GeoShapeInlineQuery[Any] =
+    GeoShapeInline(
+      field = field,
+      shape = shape,
+      relation = None
     )
 
   /**

--- a/modules/library/src/main/scala/zio/elasticsearch/data/GeoShape.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/data/GeoShape.scala
@@ -20,29 +20,32 @@ import zio.Chunk
 import zio.json.ast.Json
 import zio.json.ast.Json.{Arr, Num, Obj, Str}
 
-private[elasticsearch] sealed trait GeoShape {
-  def toJson: Json
+sealed trait GeoShape {
+  private[elasticsearch] def toJson: Json
 }
 
-private[elasticsearch] final case class GeoPoint(latitude: Double, longitude: Double) extends GeoShape {
-  override def toJson: Json = Obj(
-    "type"        -> Str("point"),
-    "coordinates" -> coordinatesToJson
-  )
-
-  def coordinatesToJson: Json = Arr(Chunk(Num(longitude), Num(latitude)))
+final case class GeoLineString(coordinates: Chunk[GeoPoint]) extends GeoShape {
+  private[elasticsearch] def toJson: Json =
+    Obj(
+      "type"        -> Str("linestring"),
+      "coordinates" -> Arr(coordinates.map(_.coordinatesToJson))
+    )
 }
 
-private[elasticsearch] final case class GeoLineString(coordinates: Chunk[GeoPoint]) extends GeoShape {
-  override def toJson: Json = Obj(
-    "type"        -> Str("linestring"),
-    "coordinates" -> Arr(coordinates.map(_.coordinatesToJson))
-  )
+final case class GeoPoint(latitude: Double, longitude: Double) extends GeoShape {
+  private[elasticsearch] def toJson: Json =
+    Obj(
+      "type"        -> Str("point"),
+      "coordinates" -> coordinatesToJson
+    )
+
+  private[elasticsearch] def coordinatesToJson: Json = Arr(Chunk(Num(longitude), Num(latitude)))
 }
 
-private[elasticsearch] final case class GeoPolygon(coordinates: Chunk[GeoPoint]) extends GeoShape {
-  override def toJson: Json = Obj(
-    "type"        -> Str("polygon"),
-    "coordinates" -> Arr(Arr(coordinates.map(_.coordinatesToJson)))
-  )
+final case class GeoPolygon(coordinates: Chunk[GeoPoint]) extends GeoShape {
+  private[elasticsearch] def toJson: Json =
+    Obj(
+      "type"        -> Str("polygon"),
+      "coordinates" -> Arr(Arr(coordinates.map(_.coordinatesToJson)))
+    )
 }

--- a/modules/library/src/main/scala/zio/elasticsearch/data/GeoShape.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/data/GeoShape.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 LambdaWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.elasticsearch.data
+
+import zio.Chunk
+import zio.json.ast.Json
+import zio.json.ast.Json.{Arr, Num, Obj, Str}
+
+private[elasticsearch] sealed trait GeoShape {
+  def toJson: Json
+}
+
+private[elasticsearch] final case class GeoPoint(latitude: Double, longitude: Double) extends GeoShape {
+  override def toJson: Json = Obj(
+    "type"        -> Str("point"),
+    "coordinates" -> coordinatesToJson
+  )
+
+  def coordinatesToJson: Json = Arr(Chunk(Num(longitude), Num(latitude)))
+}
+
+private[elasticsearch] final case class GeoLineString(coordinates: Chunk[GeoPoint]) extends GeoShape {
+  override def toJson: Json = Obj(
+    "type"        -> Str("linestring"),
+    "coordinates" -> Arr(coordinates.map(_.coordinatesToJson))
+  )
+}
+
+private[elasticsearch] final case class GeoPolygon(coordinates: Chunk[GeoPoint]) extends GeoShape {
+  override def toJson: Json = Obj(
+    "type"        -> Str("polygon"),
+    "coordinates" -> Arr(Arr(coordinates.map(_.coordinatesToJson)))
+  )
+}

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -429,7 +429,6 @@ sealed trait GeoShapeInlineQuery[S] extends ElasticQuery[S] {
    *
    * @param value
    *   One of spatial relation operators: intersects, contained, within or disjoint.
-   *
    * @return
    *   an instance of [[zio.elasticsearch.query.GeoShapeInlineQuery]] enriched with the `relation` parameter.
    */

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -428,7 +428,7 @@ sealed trait GeoShapeInlineQuery[S] extends ElasticQuery[S] {
    * spatial relation operators may be used at search time. See [[zio.elasticsearch.query.SpatialRelation]].
    *
    * @param value
-   *   One of spatial relation operators: intersects, contained, within or disjoint.
+   *   one of spatial relation operators: intersects, contained, within or disjoint
    * @return
    *   an instance of [[zio.elasticsearch.query.GeoShapeInlineQuery]] enriched with the `relation` parameter.
    */

--- a/modules/library/src/main/scala/zio/elasticsearch/query/SpatialRelation.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/SpatialRelation.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 LambdaWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.elasticsearch.query
+
+import zio.json.ast.Json
+import zio.json.ast.Json.Str
+
+sealed trait SpatialRelation {
+  def value: String
+  def toJson: Json = Str(value)
+}
+
+object SpatialRelation {
+  case object Intersects extends SpatialRelation { def value: String = "intersects" }
+  case object Disjoint   extends SpatialRelation { def value: String = "disjoint"   }
+  case object Within     extends SpatialRelation { def value: String = "within"     }
+  case object Contains   extends SpatialRelation { def value: String = "contains"   }
+}

--- a/modules/library/src/main/scala/zio/elasticsearch/query/SpatialRelation.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/SpatialRelation.scala
@@ -25,8 +25,8 @@ sealed trait SpatialRelation {
 }
 
 object SpatialRelation {
-  case object Intersects extends SpatialRelation { def value: String = "intersects" }
-  case object Disjoint   extends SpatialRelation { def value: String = "disjoint"   }
-  case object Within     extends SpatialRelation { def value: String = "within"     }
   case object Contains   extends SpatialRelation { def value: String = "contains"   }
+  case object Disjoint   extends SpatialRelation { def value: String = "disjoint"   }
+  case object Intersects extends SpatialRelation { def value: String = "intersects" }
+  case object Within     extends SpatialRelation { def value: String = "within"     }
 }

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -673,8 +673,7 @@ object ElasticQuerySpec extends ZIOSpecDefault {
                 relation = None
               )
             )
-          ) &&
-          assert(queryWithGeoPoint)(
+          ) && assert(queryWithGeoPoint)(
             equalTo(
               GeoShapeInline[TestDocument](
                 field = "locationField",
@@ -682,8 +681,7 @@ object ElasticQuerySpec extends ZIOSpecDefault {
                 relation = Some(SpatialRelation.Intersects)
               )
             )
-          ) &&
-          assert(queryWithGeoLine)(
+          ) && assert(queryWithGeoLine)(
             equalTo(
               GeoShapeInline[TestDocument](
                 field = "locationField",

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -651,6 +651,59 @@ object ElasticQuerySpec extends ZIOSpecDefault {
             )
           )
         },
+        test("geoShapeInline") {
+          val query =
+            geoShapeInline("testField", GeoPoint(20.0, 21.1))
+          val queryWithGeoPoint =
+            geoShapeInline(TestDocument.locationField, GeoPoint(20.0, 21.1)).relation(SpatialRelation.Intersects)
+          val queryWithGeoLine =
+            geoShapeInline(TestDocument.locationField, GeoLineString(Chunk(GeoPoint(20.0, 21.1), GeoPoint(21.0, 22.1))))
+              .relation(SpatialRelation.Contains)
+          val queryWithAllParams =
+            geoShapeInline(
+              TestDocument.locationField,
+              GeoPolygon(Chunk(GeoPoint(20.0, 21.1), GeoPoint(21.0, 22.1), GeoPoint(43.0, 43.1), GeoPoint(20.0, 21.1)))
+            ).relation(SpatialRelation.Contains)
+
+          assert(query)(
+            equalTo(
+              GeoShapeInline[Any](
+                field = "testField",
+                shape = GeoPoint(20.0, 21.1),
+                relation = None
+              )
+            )
+          ) &&
+          assert(queryWithGeoPoint)(
+            equalTo(
+              GeoShapeInline[TestDocument](
+                field = "locationField",
+                shape = GeoPoint(20.0, 21.1),
+                relation = Some(SpatialRelation.Intersects)
+              )
+            )
+          ) &&
+          assert(queryWithGeoLine)(
+            equalTo(
+              GeoShapeInline[TestDocument](
+                field = "locationField",
+                shape = GeoLineString(Chunk(GeoPoint(20.0, 21.1), GeoPoint(21.0, 22.1))),
+                relation = Some(SpatialRelation.Contains)
+              )
+            )
+          ) && assert(queryWithAllParams)(
+            equalTo(
+              GeoShapeInline[TestDocument](
+                field = "locationField",
+                shape = GeoPolygon(
+                  Chunk(GeoPoint(20.0, 21.1), GeoPoint(21.0, 22.1), GeoPoint(43.0, 43.1), GeoPoint(20.0, 21.1))
+                ),
+                relation = Some(SpatialRelation.Contains)
+              )
+            )
+          )
+
+        },
         test("hasChild") {
           val query                   = hasChild("child", matchAll)
           val queryWithIgnoreUnmapped = hasChild("child", matchAll).ignoreUnmappedTrue


### PR DESCRIPTION
Part of #91 

Implement part of the `geo_shape` query.

Currently supported `geo_shapes`:
- point
- linestring
- polygon

This support only the creation of an inline `geo_shape` query. `Pre-Indexed Shape` is not yet supported. 