### PR TITLE
(dsl): Support `matchPhrasePrefix` query

### DIFF
--- a/docs/overview/queries/elastic_query_match_phrase_prefix.md
+++ b/docs/overview/queries/elastic_query_match_phrase_prefix.md
@@ -3,7 +3,7 @@ id: elastic_query_match_phrase_prefix
 title: "Match Phrase Prefix Query"
 ---
 
-The `MatchPhrasePrefix` returns documents that contain the words of a provided text, in the same order as provided. 
+The `MatchPhrasePrefix` query returns documents that contain the words of a provided text, in the same order as provided. 
 The last term of the provided text is treated as a prefix, matching any words that begin with that term.
 
 In order to use the `MatchPhrasePrefix` query import the following:
@@ -23,3 +23,4 @@ val query: MatchPhrasePrefixQuery = matchPhrasePrefix(field = Document.stringFie
 ```
 
 You can find more information about `MatchPhrasePrefix` query [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-match-query-phrase-prefix.html).
+

--- a/docs/overview/queries/elastic_query_match_phrase_prefix.md
+++ b/docs/overview/queries/elastic_query_match_phrase_prefix.md
@@ -1,0 +1,25 @@
+---
+id: elastic_query_match_phrase_prefix
+title: "Match Phrase Prefix Query"
+---
+
+The `MatchPhrasePrefix` returns documents that contain the words of a provided text, in the same order as provided. 
+The last term of the provided text is treated as a prefix, matching any words that begin with that term.
+
+In order to use the `MatchPhrasePrefix` query import the following:
+```scala
+import zio.elasticsearch.query.MatchPhrasePrefixQuery
+import zio.elasticsearch.ElasticQuery._
+```
+
+You can create a `MatchPhrasePrefix` query using the `matchPhrasePrefix` method this way:
+```scala
+val query: MatchPhrasePrefixQuery = matchPhrasePrefix(field = "stringField", value = "test")
+```
+
+You can create a [type-safe](https://lambdaworks.github.io/zio-elasticsearch/overview/overview_zio_prelude_schema) `MatchPhrasePrefix` query using the `matchPhrasePrefix` method this way:
+```scala
+val query: MatchPhrasePrefixQuery = matchPhrasePrefix(field = Document.stringField, value = "test")
+```
+
+You can find more information about `MatchPhrasePrefix` query [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-match-query-phrase-prefix.html).

--- a/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -959,7 +959,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                             value = s"${firstDocument.stringField} te"
                           )
                   res <- Executor.execute(ElasticRequest.search(firstSearchIndex, query)).documentAs[TestDocument]
-                } yield assert(res)(Assertion.contains(document))
+                } yield (assert(res)(Assertion.contains(document)) && assert(res)(!Assertion.contains(secondDocument)))
             }
           } @@ around(
             Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -456,7 +456,7 @@ object ElasticQuery {
    * @param field
    *   the type-safe field for which query is specified for
    * @param value
-   *   the value to be matched, represented by an instance of type `String`
+   *   the text value to be matched
    * @tparam S
    *   document for which field query is executed
    * @return
@@ -475,7 +475,7 @@ object ElasticQuery {
    * @param field
    *   the field for which query is specified for
    * @param value
-   *   the value to be matched, represented by an instance of type `String`
+   *   the text value to be matched
    * @return
    *   an instance of [[zio.elasticsearch.query.MatchPhrasePrefixQuery]] that represents the match phrase prefix query
    *   to be performed.

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -448,6 +448,42 @@ object ElasticQuery {
     MatchPhrase(field = field, value = value, boost = None)
 
   /**
+   * Constructs a type-safe instance of [[zio.elasticsearch.query.MatchPhrasePrefixQuery]] using the specified
+   * parameters. [[zio.elasticsearch.query.MatchPhrasePrefixQuery]] returns documents that contain the words of a
+   * provided text, in the same order as provided. The last term of the provided text is treated as a prefix, matching
+   * any words that begin with that term.
+   *
+   * @param field
+   *   the type-safe field for which query is specified for
+   * @param value
+   *   the value to be matched, represented by an instance of type `String`
+   * @tparam S
+   *   document for which field query is executed
+   * @return
+   *   an instance of [[zio.elasticsearch.query.MatchPhrasePrefixQuery]] that represents the match phrase prefix query
+   *   to be performed.
+   */
+  final def matchPhrasePrefix[S](field: Field[S, String], value: String): MatchPhrasePrefixQuery[S] =
+    MatchPhrasePrefix(field = field.toString, value = value)
+
+  /**
+   * Constructs an instance of [[zio.elasticsearch.query.MatchPhrasePrefixQuery]] using the specified parameters.
+   * [[zio.elasticsearch.query.MatchPhrasePrefixQuery]] returns documents that contain the words of a provided text, in
+   * the same order as provided. The last term of the provided text is treated as a prefix, matching any words that
+   * begin with that term.
+   *
+   * @param field
+   *   the field for which query is specified for
+   * @param value
+   *   the value to be matched, represented by an instance of type `String`
+   * @return
+   *   an instance of [[zio.elasticsearch.query.MatchPhrasePrefixQuery]] that represents the match phrase prefix query
+   *   to be performed.
+   */
+  final def matchPhrasePrefix(field: String, value: String): MatchPhrasePrefixQuery[Any] =
+    MatchPhrasePrefix(field = field, value = value)
+
+  /**
    * Constructs a type-safe instance of [[zio.elasticsearch.query.BoolQuery]] with queries that must satisfy the
    * criteria using the specified parameters.
    *

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -590,7 +590,7 @@ private[elasticsearch] final case class MatchPhrasePrefix[S](field: String, valu
     extends MatchPhrasePrefixQuery[S] {
 
   private[elasticsearch] def toJson(fieldPath: Option[String]): Json =
-    Obj("match_phrase_prefix" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson))
+    Obj("match_phrase_prefix" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> Obj("query" -> value.toJson)))
 }
 
 sealed trait NestedQuery[S]

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -587,7 +587,8 @@ private[elasticsearch] final case class MatchPhrase[S](field: String, value: Str
 sealed trait MatchPhrasePrefixQuery[S] extends ElasticQuery[S]
 
 private[elasticsearch] final case class MatchPhrasePrefix[S](field: String, value: String)
-    extends MatchPhrasePrefixQuery[S] {
+  extends MatchPhrasePrefixQuery[S] {
+
   private[elasticsearch] def toJson(fieldPath: Option[String]): Json =
     Obj("match_phrase_prefix" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson))
 }

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -584,6 +584,14 @@ private[elasticsearch] final case class MatchPhrase[S](field: String, value: Str
     )
 }
 
+sealed trait MatchPhrasePrefixQuery[S] extends ElasticQuery[S]
+
+private[elasticsearch] final case class MatchPhrasePrefix[S](field: String, value: String)
+    extends MatchPhrasePrefixQuery[S] {
+  private[elasticsearch] def toJson(fieldPath: Option[String]): Json =
+    Obj("match_phrase_prefix" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson))
+}
+
 sealed trait NestedQuery[S]
     extends ElasticQuery[S]
     with HasIgnoreUnmapped[NestedQuery[S]]

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -587,7 +587,7 @@ private[elasticsearch] final case class MatchPhrase[S](field: String, value: Str
 sealed trait MatchPhrasePrefixQuery[S] extends ElasticQuery[S]
 
 private[elasticsearch] final case class MatchPhrasePrefix[S](field: String, value: String)
-  extends MatchPhrasePrefixQuery[S] {
+    extends MatchPhrasePrefixQuery[S] {
 
   private[elasticsearch] def toJson(fieldPath: Option[String]): Json =
     Obj("match_phrase_prefix" -> Obj(fieldPath.foldRight(field)(_ + "." + _) -> value.toJson))

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -2477,6 +2477,22 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryRawTs.toJson(fieldPath = None))(equalTo(expectedRaw.toJson)) &&
           assert(querySimpleTsWithBoost.toJson(fieldPath = None))(equalTo(expectedSimpleTsWithBoost.toJson))
         },
+        test("matchPhrasePrefix"){
+          val query   = matchPhrasePrefix("stringField", "test")
+          val queryTs = matchPhrasePrefix(TestDocument.stringField, "test")
+
+          val expected =
+            """
+              |{
+              |  "match_phrase_prefix": {
+              |    "stringField": "test"
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
+          assert(queryTs.toJson(fieldPath = None))(equalTo(expected.toJson))
+        },
         test("nested") {
           val query                   = nested(TestDocument.subDocumentList, matchAll)
           val queryWithNested         = nested(TestDocument.subDocumentList, nested("items", term("testField", "test")))

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -895,9 +895,7 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           val queryTs = matchPhrasePrefix(TestDocument.stringField, "test")
 
           assert(query)(equalTo(MatchPhrasePrefix[Any](field = "stringField", value = "test"))) &&
-          assert(queryTs)(
-            equalTo(MatchPhrasePrefix[TestDocument](field = "stringField", value = "test"))
-          )
+          assert(queryTs)(equalTo(MatchPhrasePrefix[TestDocument](field = "stringField", value = "test")))
         },
         test("nested") {
           val query                   = nested("testField", matchAll)

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -2477,7 +2477,7 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryRawTs.toJson(fieldPath = None))(equalTo(expectedRaw.toJson)) &&
           assert(querySimpleTsWithBoost.toJson(fieldPath = None))(equalTo(expectedSimpleTsWithBoost.toJson))
         },
-        test("matchPhrasePrefix"){
+        test("matchPhrasePrefix") {
           val query   = matchPhrasePrefix("stringField", "test")
           val queryTs = matchPhrasePrefix(TestDocument.stringField, "test")
 

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -890,6 +890,15 @@ object ElasticQuerySpec extends ZIOSpecDefault {
             equalTo(MatchPhrase[TestDocument](field = "stringField", value = "this is a test", boost = Some(3)))
           )
         },
+        test("matchPhrasePrefix") {
+          val query   = matchPhrasePrefix("stringField", "test")
+          val queryTs = matchPhrasePrefix(TestDocument.stringField, "test")
+
+          assert(query)(equalTo(MatchPhrasePrefix[Any](field = "stringField", value = "test"))) &&
+          assert(queryTs)(
+            equalTo(MatchPhrasePrefix[TestDocument](field = "stringField", value = "test"))
+          )
+        },
         test("nested") {
           val query                   = nested("testField", matchAll)
           val queryTs                 = nested(TestDocument.subDocumentList, matchAll)

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -2485,7 +2485,9 @@ object ElasticQuerySpec extends ZIOSpecDefault {
             """
               |{
               |  "match_phrase_prefix": {
-              |    "stringField": "test"
+              |    "stringField": {
+              |       "query" : "test"
+              |    }
               |  }
               |}
               |""".stripMargin

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -23,6 +23,7 @@ module.exports = {
                     'overview/queries/elastic_query_match',
                     'overview/queries/elastic_query_match_all',
                     'overview/queries/elastic_query_match_phrase',
+                    'overview/queries/elastic_query_match_phrase_prefix',
                     'overview/queries/elastic_query_nested',
                     'overview/queries/elastic_query_prefix',
                     'overview/queries/elastic_query_range',


### PR DESCRIPTION
Part of #91 