### PR TITLE
(dsl): Support `regexp` query

### DIFF
--- a/docs/overview/queries/elastic_query_regexp.md
+++ b/docs/overview/queries/elastic_query_regexp.md
@@ -1,0 +1,31 @@
+---
+id: elastic_query_regexp
+title: "Regexp Query"
+---
+
+The `Regexp` query returns documents that contain terms matching a regular expression.
+
+In order to use the `Regexp` query import the following:
+```scala
+import zio.elasticsearch.query.RegexpQuery
+import zio.elasticsearch.ElasticQuery._
+```
+
+You can create a `Regexp` query using the `regexp` method this way:
+```scala
+val query: RegexpQuery = regexp(field = "name", value = "t.*st")
+```
+
+You can create a [type-safe](https://lambdaworks.github.io/zio-elasticsearch/overview/overview_zio_prelude_schema) `Regexp` query using the `regexp` method this way:
+```scala
+val query: RegexpQuery = regexp(field = Document.name, value = "t.*st")
+```
+
+If you want to change the `case_insensitive`, you can use `caseInsensitive`, `caseInsensitiveFalse` or `caseInsensitiveTrue` method:
+```scala
+val queryWithCaseInsensitive: RegexpQuery = regexp(field = Document.name, value = "t.*st").caseInsensitive(true)
+val queryWithCaseInsensitiveFalse: RegexpQuery = regexp(field = Document.name, value = "t.*st").caseInsensitiveFalse
+val queryWithCaseInsensitiveTrue: RegexpQuery = regexp(field = Document.name, value = "t.*st").caseInsensitiveTrue
+```
+
+You can find more information about `Regexp` query [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-regexp-query.html).

--- a/docs/overview/queries/elastic_query_regexp.md
+++ b/docs/overview/queries/elastic_query_regexp.md
@@ -29,3 +29,4 @@ val queryWithCaseInsensitiveTrue: RegexpQuery = regexp(field = Document.name, va
 ```
 
 You can find more information about `Regexp` query [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-regexp-query.html).
+

--- a/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -1050,7 +1050,7 @@ object HttpExecutorSpec extends IntegrationSpec {
             Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           ),
-          test("search for a document using regexp query") {
+          test("search for a document that doesn't exist using regexp query without case insensitive ") {
             checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
               (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>
                 for {
@@ -1100,7 +1100,9 @@ object HttpExecutorSpec extends IntegrationSpec {
                   res <- Executor
                            .execute(ElasticRequest.search(firstSearchIndex, query))
                            .documentAs[TestDocument]
-                } yield (assert(res)(Assertion.contains(firstDocument)) && assert(res)(!Assertion.contains(secondDocument)))
+                } yield (assert(res)(Assertion.contains(firstDocument)) && assert(res)(
+                  !Assertion.contains(secondDocument)
+                ))
             }
           } @@ around(
             Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),

--- a/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -1050,6 +1050,62 @@ object HttpExecutorSpec extends IntegrationSpec {
             Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           ),
+          test("search for a document using regexp query") {
+            checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
+              (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>
+                for {
+                  _ <- Executor.execute(ElasticRequest.deleteByQuery(firstSearchIndex, matchAll))
+                  _ <- Executor.execute(
+                         ElasticRequest.upsert[TestDocument](firstSearchIndex, firstDocumentId, firstDocument)
+                       )
+                  _ <- Executor.execute(
+                         ElasticRequest
+                           .upsert[TestDocument](firstSearchIndex, secondDocumentId, secondDocument)
+                           .refreshTrue
+                       )
+                  query =
+                    ElasticQuery.regexp(
+                      field = TestDocument.stringField,
+                      value =
+                        s"${firstDocument.stringField.take(1)}.*${firstDocument.stringField.takeRight(1)}".toUpperCase
+                    )
+                  res <- Executor
+                           .execute(ElasticRequest.search(firstSearchIndex, query))
+                           .documentAs[TestDocument]
+                } yield assert(res)(!Assertion.contains(firstDocument))
+            }
+          } @@ around(
+            Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
+            Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
+          ),
+          test("search for a document using regexp query with case insensitive") {
+            checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
+              (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>
+                for {
+                  _ <- Executor.execute(ElasticRequest.deleteByQuery(firstSearchIndex, matchAll))
+                  _ <- Executor.execute(
+                         ElasticRequest.upsert[TestDocument](firstSearchIndex, firstDocumentId, firstDocument)
+                       )
+                  _ <- Executor.execute(
+                         ElasticRequest
+                           .upsert[TestDocument](firstSearchIndex, secondDocumentId, secondDocument)
+                           .refreshTrue
+                       )
+                  query = ElasticQuery
+                            .regexp(
+                              field = TestDocument.stringField,
+                              value = s"${firstDocument.stringField.take(1)}.*${firstDocument.stringField.takeRight(1)}"
+                            )
+                            .caseInsensitiveTrue
+                  res <- Executor
+                           .execute(ElasticRequest.search(firstSearchIndex, query))
+                           .documentAs[TestDocument]
+                } yield (assert(res)(Assertion.contains(firstDocument)) && assert(res)(!Assertion.contains(secondDocument)))
+            }
+          } @@ around(
+            Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
+            Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
+          ),
           test("search for a document using script query") {
             checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
               (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -626,7 +626,7 @@ object ElasticQuery {
    * [[zio.elasticsearch.query.RegexpQuery]] returns documents that contain terms matching a regular expression.
    *
    * @param field
-   *   the field for which query is specified for
+   *   the type-safe field for which query is specified for
    * @param value
    *   regular expression that will be used for the query
    * @tparam S

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -622,6 +622,36 @@ object ElasticQuery {
     Range.empty[Any, Any](field = field)
 
   /**
+   * Constructs a type-safe instance of [[zio.elasticsearch.query.RegexpQuery]] using the specified parameters.
+   * [[zio.elasticsearch.query.RegexpQuery]] returns documents that contain terms matching a regular expression.
+   *
+   * @param field
+   *   the field for which query is specified for
+   * @param value
+   *   regular expression that will be used for the query
+   * @tparam S
+   *   document for which field query is executed
+   * @return
+   *   an instance of [[zio.elasticsearch.query.RegexpQuery]] that represents the regexp query to be performed.
+   */
+  final def regexp[S](field: Field[S, String], value: String): RegexpQuery[S] =
+    Regexp(field = field.toString, value = value, caseInsensitive = None)
+
+  /**
+   * Constructs an instance of [[zio.elasticsearch.query.RegexpQuery]] using the specified parameters.
+   * [[zio.elasticsearch.query.RegexpQuery]] returns documents that contain terms matching a regular expression.
+   *
+   * @param field
+   *   the field for which query is specified for
+   * @param value
+   *   regular expression that will be used for the query
+   * @return
+   *   an instance of [[zio.elasticsearch.query.RegexpQuery]] that represents the regexp query to be performed.
+   */
+  final def regexp(field: String, value: String): RegexpQuery[Any] =
+    Regexp(field = field, value = value, caseInsensitive = None)
+
+  /**
    * Constructs an instance of [[zio.elasticsearch.query.ScriptQuery]] with the provided script.
    * @param script
    *   the script that is used by the query

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -1166,15 +1166,21 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           )
         },
         test("regexp") {
-          val query                      = regexp("stringField", "t.*st")
-          val queryTs                    = regexp(TestDocument.stringField, "t.*st")
-          val queryWithCaseInsensitive   = regexp("stringField", "t.*st").caseInsensitiveTrue
-          val queryTsWithCaseInsensitive = regexp(TestDocument.stringField, "t.*st").caseInsensitiveTrue
+          val query                    = regexp("stringField", "t.*st")
+          val queryTs                  = regexp(TestDocument.stringField, "t.*st")
+          val queryWithCaseInsensitive = regexp(TestDocument.stringField, "t.*st").caseInsensitiveTrue
+          val queryWithSuffix          = regexp(TestDocument.stringField.raw, "t.*st")
 
           assert(query)(equalTo(Regexp[Any](field = "stringField", value = "t.*st", caseInsensitive = None))) &&
-          assert(queryTs)(equalTo(Regexp[TestDocument](field = "stringField", value = "t.*st", caseInsensitive = None))) &&
-          assert(queryWithCaseInsensitive)(equalTo(Regexp[Any](field = "stringField", value = "t.*st", caseInsensitive = Some(true)))) &&
-          assert(queryTsWithCaseInsensitive)(equalTo(Regexp[TestDocument](field = "stringField", value = "t.*st", caseInsensitive = Some(true))))
+          assert(queryTs)(
+            equalTo(Regexp[TestDocument](field = "stringField", value = "t.*st", caseInsensitive = None))
+          ) &&
+          assert(queryWithCaseInsensitive)(
+            equalTo(Regexp[TestDocument](field = "stringField", value = "t.*st", caseInsensitive = Some(true)))
+          ) &&
+          assert(queryWithSuffix)(
+            equalTo(Regexp[TestDocument](field = "stringField.raw", value = "t.*st", caseInsensitive = None))
+          )
         },
         test("script") {
           val query =
@@ -2784,10 +2790,10 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryWithFormat.toJson(fieldPath = None))(equalTo(expectedWithFormat.toJson))
         },
         test("regexp") {
-          val query                      = regexp("stringField", "t.*st")
-          val queryTs                    = regexp(TestDocument.stringField, "t.*st")
-          val queryWithCaseInsensitive   = regexp("stringField", "t.*st").caseInsensitiveTrue
-          val queryTsWithCaseInsensitive = regexp(TestDocument.stringField, "t.*st").caseInsensitiveTrue
+          val query                    = regexp("stringField", "t.*st")
+          val queryTs                  = regexp(TestDocument.stringField, "t.*st")
+          val queryWithCaseInsensitive = regexp(TestDocument.stringField, "t.*st").caseInsensitiveTrue
+          val queryWithSuffix          = regexp(TestDocument.stringField.raw, "t.*st")
 
           val expected =
             """
@@ -2812,10 +2818,21 @@ object ElasticQuerySpec extends ZIOSpecDefault {
               |}
               |""".stripMargin
 
+          val expectedWithSuffix =
+            """
+              |{
+              |  "regexp": {
+              |    "stringField.raw": {
+              |      "value": "t.*st"
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
           assert(query.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
           assert(queryTs.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
           assert(queryWithCaseInsensitive.toJson(fieldPath = None))(equalTo(expectedWithCaseInsensitive.toJson)) &&
-          assert(queryTsWithCaseInsensitive.toJson(fieldPath = None))(equalTo(expectedWithCaseInsensitive.toJson))
+          assert(queryWithSuffix.toJson(fieldPath = None))(equalTo(expectedWithSuffix.toJson))
         },
         test("script") {
           val query =

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -1165,6 +1165,17 @@ object ElasticQuerySpec extends ZIOSpecDefault {
             )
           )
         },
+        test("regexp") {
+          val query                      = regexp("stringField", "t.*st")
+          val queryTs                    = regexp(TestDocument.stringField, "t.*st")
+          val queryWithCaseInsensitive   = regexp("stringField", "t.*st").caseInsensitiveTrue
+          val queryTsWithCaseInsensitive = regexp(TestDocument.stringField, "t.*st").caseInsensitiveTrue
+
+          assert(query)(equalTo(Regexp[Any](field = "stringField", value = "t.*st", caseInsensitive = None))) &&
+          assert(queryTs)(equalTo(Regexp[TestDocument](field = "stringField", value = "t.*st", caseInsensitive = None))) &&
+          assert(queryWithCaseInsensitive)(equalTo(Regexp[Any](field = "stringField", value = "t.*st", caseInsensitive = Some(true)))) &&
+          assert(queryTsWithCaseInsensitive)(equalTo(Regexp[TestDocument](field = "stringField", value = "t.*st", caseInsensitive = Some(true))))
+        },
         test("script") {
           val query =
             ElasticQuery.script(Script("doc['day_of_week'].value > params['day']").params("day" -> 2).lang(Painless))
@@ -2771,6 +2782,40 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryMixedBounds.toJson(fieldPath = None))(equalTo(expectedMixedBounds.toJson)) &&
           assert(queryMixedBoundsWithBoost.toJson(fieldPath = None))(equalTo(expectedMixedBoundsWithBoost.toJson)) &&
           assert(queryWithFormat.toJson(fieldPath = None))(equalTo(expectedWithFormat.toJson))
+        },
+        test("regexp") {
+          val query                      = regexp("stringField", "t.*st")
+          val queryTs                    = regexp(TestDocument.stringField, "t.*st")
+          val queryWithCaseInsensitive   = regexp("stringField", "t.*st").caseInsensitiveTrue
+          val queryTsWithCaseInsensitive = regexp(TestDocument.stringField, "t.*st").caseInsensitiveTrue
+
+          val expected =
+            """
+              |{
+              |  "regexp": {
+              |    "stringField": {
+              |      "value": "t.*st"
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          val expectedWithCaseInsensitive =
+            """
+              |{
+              |  "regexp": {
+              |    "stringField": {
+              |      "value": "t.*st",
+              |      "case_insensitive": true
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
+          assert(queryTs.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
+          assert(queryWithCaseInsensitive.toJson(fieldPath = None))(equalTo(expectedWithCaseInsensitive.toJson)) &&
+          assert(queryTsWithCaseInsensitive.toJson(fieldPath = None))(equalTo(expectedWithCaseInsensitive.toJson))
         },
         test("script") {
           val query =

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -26,6 +26,7 @@ module.exports = {
                     'overview/queries/elastic_query_nested',
                     'overview/queries/elastic_query_prefix',
                     'overview/queries/elastic_query_range',
+                    'overview/queries/elastic_query_regexp',
                     'overview/queries/elastic_query_term',
                     'overview/queries/elastic_query_terms',
                     'overview/queries/elastic_query_wildcard',


### PR DESCRIPTION
Part of #91