### PR TITLE
(dsl): Support `matchBooleanPrefix` query

### DIFF
--- a/docs/overview/queries/elastic_query_match_boolean_prefix.md
+++ b/docs/overview/queries/elastic_query_match_boolean_prefix.md
@@ -1,0 +1,26 @@
+---
+id: elastic_query_match_boolean_prefix
+title: "Match Boolean Prefix Query"
+---
+
+The `MatchBooleanPrefix` query analyzes its input and constructs a `bool` query from the terms. Each term except the last is used in a `term` query. 
+The last term is used in a `prefix` query.
+
+In order to use the `MatchBooleanPrefix` query import the following:
+```scala
+import zio.elasticsearch.query.MatchBooleanPrefixQuery
+import zio.elasticsearch.ElasticQuery._
+```
+
+You can create a `MatchBooleanPrefix` query using the `matchBooleanPrefix` method this way:
+```scala
+val query: MatchBooleanPrefixQuery = matchBooleanPrefix(field = "stringField", value = "test")
+```
+
+You can create a [type-safe](https://lambdaworks.github.io/zio-elasticsearch/overview/overview_zio_prelude_schema) `MatchBooleanPrefix` query using the `matchBooleanPrefix` method this way:
+```scala
+val query: MatchBooleanPrefixQuery = matchBooleanPrefix(field = Document.stringField, value = "test")
+```
+
+You can find more information about `MatchBooleanPrefix` query [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-match-bool-prefix-query.html).
+

--- a/docs/overview/queries/elastic_query_match_boolean_prefix.md
+++ b/docs/overview/queries/elastic_query_match_boolean_prefix.md
@@ -22,5 +22,10 @@ You can create a [type-safe](https://lambdaworks.github.io/zio-elasticsearch/ove
 val query: MatchBooleanPrefixQuery = matchBooleanPrefix(field = Document.stringField, value = "test")
 ```
 
+If you want to change the `minimum_should_match` parameter, you can use the `minimumShouldMatch` method:
+```scala
+val queryWithMinimumShouldMatch: MatchBooleanPrefixQuery = matchBooleanPrefix(field = Document.stringField, value = "test").minimumShouldMatch(2)
+```
+
 You can find more information about `MatchBooleanPrefix` query [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-match-bool-prefix-query.html).
 

--- a/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -917,6 +917,48 @@ object HttpExecutorSpec extends IntegrationSpec {
             Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           ),
+          test("search for a document using a match boolean prefix query") {
+            checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
+              (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>
+                for {
+                  _       <- Executor.execute(ElasticRequest.deleteByQuery(firstSearchIndex, matchAll))
+                  document = firstDocument.copy(stringField = "test this is boolean")
+                  _ <-
+                    Executor.execute(ElasticRequest.upsert[TestDocument](firstSearchIndex, firstDocumentId, document))
+                  _ <- Executor.execute(
+                         ElasticRequest
+                           .upsert[TestDocument](firstSearchIndex, secondDocumentId, secondDocument)
+                           .refreshTrue
+                       )
+                  query = matchBooleanPrefix(TestDocument.stringField, "this is test bo")
+                  res  <- Executor.execute(ElasticRequest.search(firstSearchIndex, query)).documentAs[TestDocument]
+                } yield (assert(res)(Assertion.contains(document)) && assert(res)(!Assertion.contains(secondDocument)))
+            }
+          } @@ around(
+            Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
+            Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
+          ),
+          test("search for a document using a match boolean prefix query with minimumShouldMatch") {
+            checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
+              (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>
+                for {
+                  _       <- Executor.execute(ElasticRequest.deleteByQuery(firstSearchIndex, matchAll))
+                  document = firstDocument.copy(stringField = "test this is boolean")
+                  _ <-
+                    Executor.execute(ElasticRequest.upsert[TestDocument](firstSearchIndex, firstDocumentId, document))
+                  _ <- Executor.execute(
+                         ElasticRequest
+                           .upsert[TestDocument](firstSearchIndex, secondDocumentId, secondDocument)
+                           .refreshTrue
+                       )
+                  query = matchBooleanPrefix(TestDocument.stringField, "this test bo").minimumShouldMatch(4)
+                  res  <- Executor.execute(ElasticRequest.search(firstSearchIndex, query)).documentAs[TestDocument]
+                } yield assert(res)(!Assertion.contains(document))
+            }
+          } @@ around(
+            Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
+            Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
+          ),
           test("search for a document using a match phrase query") {
             checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
               (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>

--- a/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -938,27 +938,6 @@ object HttpExecutorSpec extends IntegrationSpec {
             Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
             Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
           ),
-          test("search for a document using a match boolean prefix query with minimumShouldMatch") {
-            checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
-              (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>
-                for {
-                  _       <- Executor.execute(ElasticRequest.deleteByQuery(firstSearchIndex, matchAll))
-                  document = firstDocument.copy(stringField = "test this is boolean")
-                  _ <-
-                    Executor.execute(ElasticRequest.upsert[TestDocument](firstSearchIndex, firstDocumentId, document))
-                  _ <- Executor.execute(
-                         ElasticRequest
-                           .upsert[TestDocument](firstSearchIndex, secondDocumentId, secondDocument)
-                           .refreshTrue
-                       )
-                  query = matchBooleanPrefix(TestDocument.stringField, "this test bo").minimumShouldMatch(4)
-                  res  <- Executor.execute(ElasticRequest.search(firstSearchIndex, query)).documentAs[TestDocument]
-                } yield assert(res)(!Assertion.contains(document))
-            }
-          } @@ around(
-            Executor.execute(ElasticRequest.createIndex(firstSearchIndex)),
-            Executor.execute(ElasticRequest.deleteIndex(firstSearchIndex)).orDie
-          ),
           test("search for a document using a match phrase query") {
             checkOnce(genDocumentId, genTestDocument, genDocumentId, genTestDocument) {
               (firstDocumentId, firstDocument, secondDocumentId, secondDocument) =>

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -416,6 +416,44 @@ object ElasticQuery {
     Match(field = field, value = value)
 
   /**
+   * Constructs a type-safe instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] using the specified
+   * parameters. [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] analyzes its input and constructs a `bool` query
+   * from the terms. Each term except the last is used in a `term` query. The last term is used in a `prefix` query.
+   *
+   * @param field
+   *   the type-safe field for which query is specified for
+   * @param value
+   *   the value to be matched, represented by an instance of type `A`
+   * @tparam S
+   *   document for which field query is executed
+   * @tparam A
+   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   * @return
+   *   an instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] that represents the match boolean prefix query
+   *   to be performed.
+   */
+  final def matchBooleanPrefix[S, A: ElasticPrimitive](field: Field[S, A], value: A): MatchBooleanPrefixQuery[S] =
+    MatchBooleanPrefix(field = field.toString, value, minimumShouldMatch = None)
+
+  /**
+   * Constructs an instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] using the specified parameters.
+   * [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] analyzes its input and constructs a `bool` query from the
+   * terms. Each term except the last is used in a `term` query. The last term is used in a `prefix` query.
+   *
+   * @param field
+   *   the field for which query is specified for
+   * @param value
+   *   the value to be matched, represented by an instance of type `A`
+   * @tparam A
+   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   * @return
+   *   an instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] that represents the match boolean prefix query
+   *   to be performed.
+   */
+  final def matchBooleanPrefix[A: ElasticPrimitive](field: String, value: A): MatchBooleanPrefixQuery[Any] =
+    MatchBooleanPrefix(field = field, value = value, minimumShouldMatch = None)
+
+  /**
    * Constructs a type-safe instance of [[zio.elasticsearch.query.MatchPhraseQuery]] using the specified parameters.
    * [[zio.elasticsearch.query.MatchPhraseQuery]] analyzes the text and creates a phrase query out of the analyzed text.
    *

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticQuery.scala
@@ -392,7 +392,7 @@ object ElasticQuery {
    * @tparam S
    *   document for which field query is executed
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @return
    *   an instance of [[zio.elasticsearch.query.MatchQuery]] that represents the match query to be performed.
    */
@@ -408,7 +408,7 @@ object ElasticQuery {
    * @param value
    *   the value to be matched, represented by an instance of type `A`
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @return
    *   an instance of [[zio.elasticsearch.query.MatchQuery]] that represents the match query to be performed.
    */
@@ -417,8 +417,9 @@ object ElasticQuery {
 
   /**
    * Constructs a type-safe instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] using the specified
-   * parameters. [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] analyzes its input and constructs a `bool` query
-   * from the terms. Each term except the last is used in a `term` query. The last term is used in a `prefix` query.
+   * parameters. [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] analyzes its input and constructs a
+   * [[zio.elasticsearch.query.BoolQuery]] from the terms. Each term except the last is used in a
+   * [[zio.elasticsearch.query.TermQuery]]. The last term is used in a [[zio.elasticsearch.query.PrefixQuery]] query.
    *
    * @param field
    *   the type-safe field for which query is specified for
@@ -427,7 +428,7 @@ object ElasticQuery {
    * @tparam S
    *   document for which field query is executed
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @return
    *   an instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] that represents the match boolean prefix query
    *   to be performed.
@@ -437,15 +438,16 @@ object ElasticQuery {
 
   /**
    * Constructs an instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] using the specified parameters.
-   * [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] analyzes its input and constructs a `bool` query from the
-   * terms. Each term except the last is used in a `term` query. The last term is used in a `prefix` query.
+   * [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] analyzes its input and constructs a
+   * [[zio.elasticsearch.query.BoolQuery]] from the terms. Each term except the last is used in a
+   * [[zio.elasticsearch.query.TermQuery]]. The last term is used in a [[zio.elasticsearch.query.PrefixQuery]].
    *
    * @param field
    *   the field for which query is specified for
    * @param value
    *   the value to be matched, represented by an instance of type `A`
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @return
    *   an instance of [[zio.elasticsearch.query.MatchBooleanPrefixQuery]] that represents the match boolean prefix query
    *   to be performed.
@@ -753,7 +755,7 @@ object ElasticQuery {
    * @param value
    *   text value that will be used for the query
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @tparam S
    *   document for which field query is executed
    * @return
@@ -772,7 +774,7 @@ object ElasticQuery {
    * @param value
    *   text value that will be used for the query
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @return
    *   an instance of [[zio.elasticsearch.query.TermQuery]] that represents the term query to be performed.
    */
@@ -792,7 +794,7 @@ object ElasticQuery {
    * @tparam S
    *   document for which field query is executed
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @return
    *   an instance of [[zio.elasticsearch.query.TermsQuery]] that represents the term query to be performed.
    */
@@ -810,7 +812,7 @@ object ElasticQuery {
    * @param values
    *   a list of terms that should be find in the provided field
    * @tparam A
-   *   the type of value to be matched. A JSON decoder must be in scope for this type
+   *   the type of value to be matched. A JSON decoder must be provided in the scope for this type
    * @return
    *   an instance of [[zio.elasticsearch.query.TermsQuery]] that represents the term query to be performed.
    */

--- a/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/query/Queries.scala
@@ -574,6 +574,7 @@ private[elasticsearch] final case class MatchBooleanPrefix[S, A: ElasticPrimitiv
   value: A,
   minimumShouldMatch: Option[Int]
 ) extends MatchBooleanPrefixQuery[S] { self =>
+
   def minimumShouldMatch(value: Int): MatchBooleanPrefixQuery[S] =
     self.copy(minimumShouldMatch = Some(value))
 

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -873,6 +873,25 @@ object ElasticQuerySpec extends ZIOSpecDefault {
             equalTo(Match[TestDocument, Double](field = "doubleField", value = 3.14))
           )
         },
+        test("matchBooleanPrefix") {
+          val queryString                   = matchBooleanPrefix("stringField", "test")
+          val queryBool                     = matchBooleanPrefix("booleanField", true)
+          val queryInt                      = matchBooleanPrefix("intField", 1)
+          val queryWithMinimumShouldMatch   = matchBooleanPrefix("stringField", "test").minimumShouldMatch(3)
+          val queryStringTs                 = matchBooleanPrefix(TestDocument.stringField, "test")
+          val queryBoolTs                   = matchBooleanPrefix(TestDocument.booleanField, true)
+          val queryIntTs                    = matchBooleanPrefix(TestDocument.intField, 1)
+          val queryWithMinimumShouldMatchTs = matchBooleanPrefix(TestDocument.stringField, "test").minimumShouldMatch(3)
+
+          assert(queryString)(equalTo(MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = None))) &&
+          assert(queryBool)(equalTo(MatchBooleanPrefix[Any, Boolean](field = "booleanField", value = true, minimumShouldMatch = None))) &&
+          assert(queryInt)(equalTo(MatchBooleanPrefix[Any, Int](field = "intField", value = 1, minimumShouldMatch = None))) &&
+          assert(queryWithMinimumShouldMatch)(equalTo(MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = Some(3)))) &&
+          assert(queryStringTs)(equalTo(MatchBooleanPrefix[TestDocument, String](field = "stringField", value = "test", minimumShouldMatch = None))) &&
+          assert(queryBoolTs)(equalTo(MatchBooleanPrefix[TestDocument, Boolean](field = "booleanField", value = true, minimumShouldMatch = None))) &&
+          assert(queryIntTs)(equalTo(MatchBooleanPrefix[TestDocument, Int](field = "intField", value = 1, minimumShouldMatch = None))) &&
+          assert(queryWithMinimumShouldMatchTs)(equalTo(MatchBooleanPrefix[TestDocument, String](field = "stringField", value = "test", minimumShouldMatch = Some(3))))
+        },
         test("matchPhrase") {
           val query           = matchPhrase("stringField", "this is a test")
           val queryTs         = matchPhrase(TestDocument.stringField, "this is a test")
@@ -2426,6 +2445,64 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(query.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
           assert(queryTsInt.toJson(fieldPath = None))(equalTo(expectedTsInt.toJson)) &&
           assert(queryTsString.toJson(fieldPath = None))(equalTo(expectedTsString.toJson))
+        },
+        test("matchBooleanPrefix") {
+          val queryString                   = matchBooleanPrefix("stringField", "test")
+          val queryBool                     = matchBooleanPrefix("booleanField", true)
+          val queryInt                      = matchBooleanPrefix("intField", 1)
+          val queryWithMinimumShouldMatch   = matchBooleanPrefix("stringField", "test").minimumShouldMatch(3)
+          val queryStringTs                 = matchBooleanPrefix(TestDocument.stringField, "test")
+          val queryBoolTs                   = matchBooleanPrefix(TestDocument.booleanField, true)
+          val queryIntTs                    = matchBooleanPrefix(TestDocument.intField, 1)
+          val queryWithMinimumShouldMatchTs = matchBooleanPrefix(TestDocument.stringField, "test").minimumShouldMatch(3)
+
+          val expectedString =
+            """
+              |{
+              |  "match_bool_prefix": {
+              |    "stringField": "test"
+              |  }
+              |}
+              |""".stripMargin
+
+          val expectedBool =
+            """
+              |{
+              |  "match_bool_prefix": {
+              |    "booleanField": true
+              |  }
+              |}
+              |""".stripMargin
+
+          val expectedInt =
+            """
+              |{
+              |  "match_bool_prefix": {
+              |    "intField": 1
+              |  }
+              |}
+              |""".stripMargin
+
+          val expectedWithMinimumShouldMatch =
+            """
+              |{
+              |  "match_bool_prefix": {
+              |    "stringField": {
+              |      "query": "test",
+              |      "minimum_should_match": 3
+              |    }
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(queryString.toJson(fieldPath = None))(equalTo(expectedString.toJson)) &&
+          assert(queryBool.toJson(fieldPath = None))(equalTo(expectedBool.toJson)) &&
+          assert(queryInt.toJson(fieldPath = None))(equalTo(expectedInt.toJson)) &&
+          assert(queryWithMinimumShouldMatch.toJson(fieldPath = None))(equalTo(expectedWithMinimumShouldMatch.toJson)) &&
+          assert(queryStringTs.toJson(fieldPath = None))(equalTo(expectedString.toJson)) &&
+          assert(queryBoolTs.toJson(fieldPath = None))(equalTo(expectedBool.toJson)) &&
+          assert(queryIntTs.toJson(fieldPath = None))(equalTo(expectedInt.toJson)) &&
+          assert(queryWithMinimumShouldMatchTs.toJson(fieldPath = None))(equalTo(expectedWithMinimumShouldMatch.toJson))
         },
         test("matchPhrase") {
           val querySimple            = matchPhrase("stringField", "this is a test")

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -846,33 +846,6 @@ object ElasticQuerySpec extends ZIOSpecDefault {
             equalTo(MatchAll(boost = Some(3.14)))
           )
         },
-        test("matches") {
-          val queryString     = matches("stringField", "test")
-          val queryBool       = matches("booleanField", true)
-          val queryInt        = matches("intField", 1)
-          val queryStringTs   = matches(TestDocument.stringField, "test")
-          val queryBoolTs     = matches(TestDocument.booleanField, true)
-          val queryIntTs      = matches(TestDocument.intField, 1)
-          val queryWithSuffix = matches(TestDocument.stringField.raw, "test")
-          val queryWithBoost  = matches(TestDocument.doubleField, 3.14)
-
-          assert(queryString)(equalTo(Match[Any, String](field = "stringField", value = "test"))) &&
-          assert(queryBool)(equalTo(Match[Any, Boolean](field = "booleanField", value = true))) &&
-          assert(queryInt)(equalTo(Match[Any, Int](field = "intField", value = 1))) &&
-          assert(queryStringTs)(
-            equalTo(Match[TestDocument, String](field = "stringField", value = "test"))
-          ) &&
-          assert(queryBoolTs)(
-            equalTo(Match[TestDocument, Boolean](field = "booleanField", value = true))
-          ) &&
-          assert(queryIntTs)(equalTo(Match[TestDocument, Int](field = "intField", value = 1))) &&
-          assert(queryWithSuffix)(
-            equalTo(Match[TestDocument, String](field = "stringField.raw", value = "test"))
-          ) &&
-          assert(queryWithBoost)(
-            equalTo(Match[TestDocument, Double](field = "doubleField", value = 3.14))
-          )
-        },
         test("matchBooleanPrefix") {
           val queryString                 = matchBooleanPrefix("stringField", "test")
           val queryBool                   = matchBooleanPrefix("booleanField", true)
@@ -922,6 +895,33 @@ object ElasticQuerySpec extends ZIOSpecDefault {
                 minimumShouldMatch = Some(3)
               )
             )
+          )
+        },
+        test("matches") {
+          val queryString     = matches("stringField", "test")
+          val queryBool       = matches("booleanField", true)
+          val queryInt        = matches("intField", 1)
+          val queryStringTs   = matches(TestDocument.stringField, "test")
+          val queryBoolTs     = matches(TestDocument.booleanField, true)
+          val queryIntTs      = matches(TestDocument.intField, 1)
+          val queryWithSuffix = matches(TestDocument.stringField.raw, "test")
+          val queryWithBoost  = matches(TestDocument.doubleField, 3.14)
+
+          assert(queryString)(equalTo(Match[Any, String](field = "stringField", value = "test"))) &&
+          assert(queryBool)(equalTo(Match[Any, Boolean](field = "booleanField", value = true))) &&
+          assert(queryInt)(equalTo(Match[Any, Int](field = "intField", value = 1))) &&
+          assert(queryStringTs)(
+            equalTo(Match[TestDocument, String](field = "stringField", value = "test"))
+          ) &&
+          assert(queryBoolTs)(
+            equalTo(Match[TestDocument, Boolean](field = "booleanField", value = true))
+          ) &&
+          assert(queryIntTs)(equalTo(Match[TestDocument, Int](field = "intField", value = 1))) &&
+          assert(queryWithSuffix)(
+            equalTo(Match[TestDocument, String](field = "stringField.raw", value = "test"))
+          ) &&
+          assert(queryWithBoost)(
+            equalTo(Match[TestDocument, Double](field = "doubleField", value = 3.14))
           )
         },
         test("matchPhrase") {
@@ -2442,42 +2442,6 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(query.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
           assert(queryWithBoost.toJson(fieldPath = None))(equalTo(expectedWithBoost.toJson))
         },
-        test("matches") {
-          val query         = matches("testField", true)
-          val queryTsInt    = matches(TestDocument.intField, 39)
-          val queryTsString = matches(TestDocument.stringField, "test")
-
-          val expected =
-            """
-              |{
-              |  "match": {
-              |    "testField": true
-              |  }
-              |}
-              |""".stripMargin
-
-          val expectedTsInt =
-            """
-              |{
-              |  "match": {
-              |    "intField": 39
-              |  }
-              |}
-              |""".stripMargin
-
-          val expectedTsString =
-            """
-              |{
-              |  "match": {
-              |    "stringField": "test"
-              |  }
-              |}
-              |""".stripMargin
-
-          assert(query.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
-          assert(queryTsInt.toJson(fieldPath = None))(equalTo(expectedTsInt.toJson)) &&
-          assert(queryTsString.toJson(fieldPath = None))(equalTo(expectedTsString.toJson))
-        },
         test("matchBooleanPrefix") {
           val queryString                 = matchBooleanPrefix("stringField", "test")
           val queryBool                   = matchBooleanPrefix("booleanField", true)
@@ -2547,6 +2511,42 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryIntTs.toJson(fieldPath = None))(equalTo(expectedInt.toJson)) &&
           assert(queryWithSuffix.toJson(fieldPath = None))(equalTo(expectedWithSuffix.toJson)) &&
           assert(queryWithMinimumShouldMatch.toJson(fieldPath = None))(equalTo(expectedWithMinimumShouldMatch.toJson))
+        },
+        test("matches") {
+          val query         = matches("testField", true)
+          val queryTsInt    = matches(TestDocument.intField, 39)
+          val queryTsString = matches(TestDocument.stringField, "test")
+
+          val expected =
+            """
+              |{
+              |  "match": {
+              |    "testField": true
+              |  }
+              |}
+              |""".stripMargin
+
+          val expectedTsInt =
+            """
+              |{
+              |  "match": {
+              |    "intField": 39
+              |  }
+              |}
+              |""".stripMargin
+
+          val expectedTsString =
+            """
+              |{
+              |  "match": {
+              |    "stringField": "test"
+              |  }
+              |}
+              |""".stripMargin
+
+          assert(query.toJson(fieldPath = None))(equalTo(expected.toJson)) &&
+          assert(queryTsInt.toJson(fieldPath = None))(equalTo(expectedTsInt.toJson)) &&
+          assert(queryTsString.toJson(fieldPath = None))(equalTo(expectedTsString.toJson))
         },
         test("matchPhrase") {
           val querySimple            = matchPhrase("stringField", "this is a test")

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -883,14 +883,42 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           val queryIntTs                    = matchBooleanPrefix(TestDocument.intField, 1)
           val queryWithMinimumShouldMatchTs = matchBooleanPrefix(TestDocument.stringField, "test").minimumShouldMatch(3)
 
-          assert(queryString)(equalTo(MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = None))) &&
-          assert(queryBool)(equalTo(MatchBooleanPrefix[Any, Boolean](field = "booleanField", value = true, minimumShouldMatch = None))) &&
-          assert(queryInt)(equalTo(MatchBooleanPrefix[Any, Int](field = "intField", value = 1, minimumShouldMatch = None))) &&
-          assert(queryWithMinimumShouldMatch)(equalTo(MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = Some(3)))) &&
-          assert(queryStringTs)(equalTo(MatchBooleanPrefix[TestDocument, String](field = "stringField", value = "test", minimumShouldMatch = None))) &&
-          assert(queryBoolTs)(equalTo(MatchBooleanPrefix[TestDocument, Boolean](field = "booleanField", value = true, minimumShouldMatch = None))) &&
-          assert(queryIntTs)(equalTo(MatchBooleanPrefix[TestDocument, Int](field = "intField", value = 1, minimumShouldMatch = None))) &&
-          assert(queryWithMinimumShouldMatchTs)(equalTo(MatchBooleanPrefix[TestDocument, String](field = "stringField", value = "test", minimumShouldMatch = Some(3))))
+          assert(queryString)(
+            equalTo(MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = None))
+          ) &&
+          assert(queryBool)(
+            equalTo(MatchBooleanPrefix[Any, Boolean](field = "booleanField", value = true, minimumShouldMatch = None))
+          ) &&
+          assert(queryInt)(
+            equalTo(MatchBooleanPrefix[Any, Int](field = "intField", value = 1, minimumShouldMatch = None))
+          ) &&
+          assert(queryWithMinimumShouldMatch)(
+            equalTo(
+              MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = Some(3))
+            )
+          ) &&
+          assert(queryStringTs)(
+            equalTo(
+              MatchBooleanPrefix[TestDocument, String](field = "stringField", value = "test", minimumShouldMatch = None)
+            )
+          ) &&
+          assert(queryBoolTs)(
+            equalTo(
+              MatchBooleanPrefix[TestDocument, Boolean](field = "booleanField", value = true, minimumShouldMatch = None)
+            )
+          ) &&
+          assert(queryIntTs)(
+            equalTo(MatchBooleanPrefix[TestDocument, Int](field = "intField", value = 1, minimumShouldMatch = None))
+          ) &&
+          assert(queryWithMinimumShouldMatchTs)(
+            equalTo(
+              MatchBooleanPrefix[TestDocument, String](
+                field = "stringField",
+                value = "test",
+                minimumShouldMatch = Some(3)
+              )
+            )
+          )
         },
         test("matchPhrase") {
           val query           = matchPhrase("stringField", "this is a test")
@@ -2498,7 +2526,9 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryString.toJson(fieldPath = None))(equalTo(expectedString.toJson)) &&
           assert(queryBool.toJson(fieldPath = None))(equalTo(expectedBool.toJson)) &&
           assert(queryInt.toJson(fieldPath = None))(equalTo(expectedInt.toJson)) &&
-          assert(queryWithMinimumShouldMatch.toJson(fieldPath = None))(equalTo(expectedWithMinimumShouldMatch.toJson)) &&
+          assert(queryWithMinimumShouldMatch.toJson(fieldPath = None))(
+            equalTo(expectedWithMinimumShouldMatch.toJson)
+          ) &&
           assert(queryStringTs.toJson(fieldPath = None))(equalTo(expectedString.toJson)) &&
           assert(queryBoolTs.toJson(fieldPath = None))(equalTo(expectedBool.toJson)) &&
           assert(queryIntTs.toJson(fieldPath = None))(equalTo(expectedInt.toJson)) &&

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticQuerySpec.scala
@@ -874,14 +874,14 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           )
         },
         test("matchBooleanPrefix") {
-          val queryString                   = matchBooleanPrefix("stringField", "test")
-          val queryBool                     = matchBooleanPrefix("booleanField", true)
-          val queryInt                      = matchBooleanPrefix("intField", 1)
-          val queryWithMinimumShouldMatch   = matchBooleanPrefix("stringField", "test").minimumShouldMatch(3)
-          val queryStringTs                 = matchBooleanPrefix(TestDocument.stringField, "test")
-          val queryBoolTs                   = matchBooleanPrefix(TestDocument.booleanField, true)
-          val queryIntTs                    = matchBooleanPrefix(TestDocument.intField, 1)
-          val queryWithMinimumShouldMatchTs = matchBooleanPrefix(TestDocument.stringField, "test").minimumShouldMatch(3)
+          val queryString                 = matchBooleanPrefix("stringField", "test")
+          val queryBool                   = matchBooleanPrefix("booleanField", true)
+          val queryInt                    = matchBooleanPrefix("intField", 1)
+          val queryStringTs               = matchBooleanPrefix(TestDocument.stringField, "test")
+          val queryBoolTs                 = matchBooleanPrefix(TestDocument.booleanField, true)
+          val queryIntTs                  = matchBooleanPrefix(TestDocument.intField, 1)
+          val queryWithSuffix             = matchBooleanPrefix(TestDocument.stringField.raw, "test")
+          val queryWithMinimumShouldMatch = matchBooleanPrefix(TestDocument.stringField, "test").minimumShouldMatch(3)
 
           assert(queryString)(
             equalTo(MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = None))
@@ -891,11 +891,6 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           ) &&
           assert(queryInt)(
             equalTo(MatchBooleanPrefix[Any, Int](field = "intField", value = 1, minimumShouldMatch = None))
-          ) &&
-          assert(queryWithMinimumShouldMatch)(
-            equalTo(
-              MatchBooleanPrefix[Any, String](field = "stringField", value = "test", minimumShouldMatch = Some(3))
-            )
           ) &&
           assert(queryStringTs)(
             equalTo(
@@ -910,7 +905,16 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryIntTs)(
             equalTo(MatchBooleanPrefix[TestDocument, Int](field = "intField", value = 1, minimumShouldMatch = None))
           ) &&
-          assert(queryWithMinimumShouldMatchTs)(
+          assert(queryWithSuffix)(
+            equalTo(
+              MatchBooleanPrefix[TestDocument, String](
+                field = "stringField.raw",
+                value = "test",
+                minimumShouldMatch = None
+              )
+            )
+          ) &&
+          assert(queryWithMinimumShouldMatch)(
             equalTo(
               MatchBooleanPrefix[TestDocument, String](
                 field = "stringField",
@@ -2475,14 +2479,14 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryTsString.toJson(fieldPath = None))(equalTo(expectedTsString.toJson))
         },
         test("matchBooleanPrefix") {
-          val queryString                   = matchBooleanPrefix("stringField", "test")
-          val queryBool                     = matchBooleanPrefix("booleanField", true)
-          val queryInt                      = matchBooleanPrefix("intField", 1)
-          val queryWithMinimumShouldMatch   = matchBooleanPrefix("stringField", "test").minimumShouldMatch(3)
-          val queryStringTs                 = matchBooleanPrefix(TestDocument.stringField, "test")
-          val queryBoolTs                   = matchBooleanPrefix(TestDocument.booleanField, true)
-          val queryIntTs                    = matchBooleanPrefix(TestDocument.intField, 1)
-          val queryWithMinimumShouldMatchTs = matchBooleanPrefix(TestDocument.stringField, "test").minimumShouldMatch(3)
+          val queryString                 = matchBooleanPrefix("stringField", "test")
+          val queryBool                   = matchBooleanPrefix("booleanField", true)
+          val queryInt                    = matchBooleanPrefix("intField", 1)
+          val queryStringTs               = matchBooleanPrefix(TestDocument.stringField, "test")
+          val queryBoolTs                 = matchBooleanPrefix(TestDocument.booleanField, true)
+          val queryIntTs                  = matchBooleanPrefix(TestDocument.intField, 1)
+          val queryWithSuffix             = matchBooleanPrefix(TestDocument.stringField.raw, "test")
+          val queryWithMinimumShouldMatch = matchBooleanPrefix(TestDocument.stringField, "test").minimumShouldMatch(3)
 
           val expectedString =
             """
@@ -2511,6 +2515,15 @@ object ElasticQuerySpec extends ZIOSpecDefault {
               |}
               |""".stripMargin
 
+          val expectedWithSuffix =
+            """
+              |{
+              |  "match_bool_prefix": {
+              |    "stringField.raw": "test"
+              |  }
+              |}
+              |""".stripMargin
+
           val expectedWithMinimumShouldMatch =
             """
               |{
@@ -2532,7 +2545,8 @@ object ElasticQuerySpec extends ZIOSpecDefault {
           assert(queryStringTs.toJson(fieldPath = None))(equalTo(expectedString.toJson)) &&
           assert(queryBoolTs.toJson(fieldPath = None))(equalTo(expectedBool.toJson)) &&
           assert(queryIntTs.toJson(fieldPath = None))(equalTo(expectedInt.toJson)) &&
-          assert(queryWithMinimumShouldMatchTs.toJson(fieldPath = None))(equalTo(expectedWithMinimumShouldMatch.toJson))
+          assert(queryWithSuffix.toJson(fieldPath = None))(equalTo(expectedWithSuffix.toJson)) &&
+          assert(queryWithMinimumShouldMatch.toJson(fieldPath = None))(equalTo(expectedWithMinimumShouldMatch.toJson))
         },
         test("matchPhrase") {
           val querySimple            = matchPhrase("stringField", "this is a test")

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -22,6 +22,7 @@ module.exports = {
                     'overview/queries/elastic_query_has_parent',
                     'overview/queries/elastic_query_match',
                     'overview/queries/elastic_query_match_all',
+                    'overview/queries/elastic_query_match_boolean_prefix',
                     'overview/queries/elastic_query_match_phrase',
                     'overview/queries/elastic_query_nested',
                     'overview/queries/elastic_query_prefix',


### PR DESCRIPTION
Part of #91 