### PR TITLE
(dsl): Support `Percentile ranks` aggregation

### DIFF
--- a/docs/overview/aggregations/elastic_aggregation_percentile_ranks.md
+++ b/docs/overview/aggregations/elastic_aggregation_percentile_ranks.md
@@ -1,0 +1,36 @@
+---
+id: elastic_aggregation_percentile_ranks
+title: "Percentiles Aggregation"
+---
+
+The `Percentile ranks` aggregation is a multi-value metrics aggregation that calculates percentile of values at or below a threshold grouped by a specified value.
+
+In order to use the `Percentile ranks` aggregation import the following:
+```scala
+import zio.elasticsearch.aggregation.PercentileRanksAggregation
+import zio.elasticsearch.ElasticAggregation.percentileRanksAggregation
+```
+
+You can create a `Percentile ranks` aggregation using the `percentileRanksAggregation` method this way:
+```scala
+val aggregation: PercentileRanksAggregation = percentileRanksAggregation(field = "intField", name = "percentileRanksAggregation", values = 500, 600)
+```
+
+You can create a [type-safe](https://lambdaworks.github.io/zio-elasticsearch/overview/overview_zio_prelude_schema) `Percentile ranks` aggregation using the `percentileRanksAggregation` method this way:
+```scala
+// Document.intField must be number value
+val aggregation: PercentileRanksAggregation = percentileRanksAggregation(field = Document.intField, name = "percentileRanksAggregation", values = 500, 600)
+```
+
+If you want to change the `missing`, you can use `missing` method:
+```scala
+val aggregationWithMissing: PercentileRanksAggregation = percentileRanksAggregation(field = Document.intField, name = "percentileRanksAggregation", values = 500, 600).missing(10.0)
+```
+
+If you want to add aggregation (on the same level), you can use `withAgg` method:
+```scala
+val multipleAggregations: MultipleAggregations = percentileRanksAggregation(field = Document.intField, name = "percentileRanksAggregation1", values = 500, 600).withAgg(percentileRanksAggregation(field = Document.doubleField, name = "percentileRanksAggregation2", values = 500, 600))
+```
+
+You can find more information about `Percentile ranks` aggregation [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-rank-aggregation.html).
+

--- a/docs/overview/aggregations/elastic_aggregation_percentile_ranks.md
+++ b/docs/overview/aggregations/elastic_aggregation_percentile_ranks.md
@@ -33,4 +33,3 @@ val multipleAggregations: MultipleAggregations = percentileRanksAggregation(fiel
 ```
 
 You can find more information about `Percentile ranks` aggregation [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-rank-aggregation.html).
-

--- a/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -277,7 +277,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                            .refreshTrue
                        )
                   aggregation =
-                    percentileRanksAggregation(name = "aggregation", field = "intField", value = 500, values = 600)
+                    percentileRanksAggregation(name = "aggregation", field = "intField", value = 500.0, values = 600.0)
                   aggsRes <-
                     Executor
                       .execute(ElasticRequest.aggregate(selectors = firstSearchIndex, aggregation = aggregation))

--- a/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
+++ b/modules/integration/src/test/scala/zio/elasticsearch/HttpExecutorSpec.scala
@@ -277,7 +277,7 @@ object HttpExecutorSpec extends IntegrationSpec {
                            .refreshTrue
                        )
                   aggregation =
-                    percentileRanksAggregation(field = "intField", name = "aggregation", values = 500, 600)
+                    percentileRanksAggregation(name = "aggregation", field = "intField", value = 500, values = 600)
                   aggsRes <-
                     Executor
                       .execute(ElasticRequest.aggregate(selectors = firstSearchIndex, aggregation = aggregation))

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
@@ -258,10 +258,14 @@ object ElasticAggregation {
    * Constructs a type-safe instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] using the specified
    * parameters.
    *
-   * @param field
-   *   the type-safe field for which stats aggregation will be executed
    * @param name
    *   the name of the aggregation
+   * @param field
+   *   the type-safe field for which percentile ranks aggregation will be executed
+   * @param value
+   *   the first value to be calculated for [[zio.elasticsearch.aggregation.PercentileRanksAggregation]]
+   * @param values
+   *   an array of values to be calculated for [[zio.elasticsearch.aggregation.PercentileRanksAggregation]]
    * @tparam A
    *   expected number type
    * @return
@@ -269,26 +273,36 @@ object ElasticAggregation {
    *   aggregation to be performed.
    */
   final def percentileRanksAggregation[A: Numeric](
-    field: Field[_, A],
     name: String,
+    field: Field[_, A],
+    value: Int,
     values: Int*
   ): PercentileRanksAggregation =
-    PercentileRanks(field = field.toString, name = name, values = Chunk.fromIterable(values), missing = None)
+    PercentileRanks(name = name, field = field.toString, values = value +: Chunk.fromIterable(values), missing = None)
 
   /**
    * Constructs an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] using the specified
    * parameters.
    *
-   * @param field
-   *   the field for which stats aggregation will be executed
    * @param name
    *   the name of the aggregation
+   * @param field
+   *   the field for which percentile ranks aggregation will be executed
+   * @param value
+   *   the first value to be calculated for [[zio.elasticsearch.aggregation.PercentileRanksAggregation]]
+   * @param values
+   *   an array of values to be calculated for [[zio.elasticsearch.aggregation.PercentileRanksAggregation]]
    * @return
    *   an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] that represents percentile ranks
    *   aggregation to be performed.
    */
-  final def percentileRanksAggregation(field: String, name: String, values: Int*): PercentileRanksAggregation =
-    PercentileRanks(field = field, name = name, values = Chunk.fromIterable(values), missing = None)
+  final def percentileRanksAggregation(
+    name: String,
+    field: String,
+    value: Int,
+    values: Int*
+  ): PercentileRanksAggregation =
+    PercentileRanks(name = name, field = field, values = value +: Chunk.fromIterable(values), missing = None)
 
   /**
    * Constructs a type-safe instance of [[zio.elasticsearch.aggregation.PercentilesAggregation]] using the specified

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
@@ -275,15 +275,13 @@ object ElasticAggregation {
   final def percentileRanksAggregation[A: Numeric](
     name: String,
     field: Field[_, A],
-    value: A,
-    values: A*
+    value: BigDecimal,
+    values: BigDecimal*
   ): PercentileRanksAggregation =
     PercentileRanks(
       name = name,
       field = field.toString,
-      values = Chunk.fromIterable(
-        implicitly[Numeric[A]].toDouble(value) +: values.map(v => implicitly[Numeric[A]].toDouble(v))
-      ),
+      values = value +: Chunk.fromIterable(values),
       missing = None
     )
 
@@ -303,18 +301,16 @@ object ElasticAggregation {
    *   an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] that represents percentile ranks
    *   aggregation to be performed.
    */
-  final def percentileRanksAggregation[A: Numeric](
+  final def percentileRanksAggregation(
     name: String,
     field: String,
-    value: A,
-    values: A*
+    value: BigDecimal,
+    values: BigDecimal*
   ): PercentileRanksAggregation =
     PercentileRanks(
       name = name,
       field = field,
-      values = Chunk.fromIterable(
-        implicitly[Numeric[A]].toDouble(value) +: values.map(v => implicitly[Numeric[A]].toDouble(v))
-      ),
+      values = value +: Chunk.fromIterable(values),
       missing = None
     )
 

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
@@ -255,6 +255,42 @@ object ElasticAggregation {
     Multiple(aggregations = Chunk.empty)
 
   /**
+   * Constructs a type-safe instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] using the specified
+   * parameters.
+   *
+   * @param field
+   *   the type-safe field for which stats aggregation will be executed
+   * @param name
+   *   the name of the aggregation
+   * @tparam A
+   *   expected number type
+   * @return
+   *   an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] that represents percentile ranks
+   *   aggregation to be performed.
+   */
+  final def percentileRanksAggregation[A: Numeric](
+    field: Field[_, A],
+    name: String,
+    values: Int*
+  ): PercentileRanksAggregation =
+    PercentileRanks(field = field.toString, name = name, values = Chunk.fromIterable(values), missing = None)
+
+  /**
+   * Constructs an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] using the specified
+   * parameters.
+   *
+   * @param field
+   *   the field for which stats aggregation will be executed
+   * @param name
+   *   the name of the aggregation
+   * @return
+   *   an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] that represents percentile ranks
+   *   aggregation to be performed.
+   */
+  final def percentileRanksAggregation(field: String, name: String, values: Int*): PercentileRanksAggregation =
+    PercentileRanks(field = field, name = name, values = Chunk.fromIterable(values), missing = None)
+
+  /**
    * Constructs a type-safe instance of [[zio.elasticsearch.aggregation.PercentilesAggregation]] using the specified
    * parameters.
    *

--- a/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/ElasticAggregation.scala
@@ -275,10 +275,17 @@ object ElasticAggregation {
   final def percentileRanksAggregation[A: Numeric](
     name: String,
     field: Field[_, A],
-    value: Int,
-    values: Int*
+    value: A,
+    values: A*
   ): PercentileRanksAggregation =
-    PercentileRanks(name = name, field = field.toString, values = value +: Chunk.fromIterable(values), missing = None)
+    PercentileRanks(
+      name = name,
+      field = field.toString,
+      values = Chunk.fromIterable(
+        implicitly[Numeric[A]].toDouble(value) +: values.map(v => implicitly[Numeric[A]].toDouble(v))
+      ),
+      missing = None
+    )
 
   /**
    * Constructs an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] using the specified
@@ -296,13 +303,20 @@ object ElasticAggregation {
    *   an instance of [[zio.elasticsearch.aggregation.PercentileRanksAggregation]] that represents percentile ranks
    *   aggregation to be performed.
    */
-  final def percentileRanksAggregation(
+  final def percentileRanksAggregation[A: Numeric](
     name: String,
     field: String,
-    value: Int,
-    values: Int*
+    value: A,
+    values: A*
   ): PercentileRanksAggregation =
-    PercentileRanks(name = name, field = field, values = value +: Chunk.fromIterable(values), missing = None)
+    PercentileRanks(
+      name = name,
+      field = field,
+      values = Chunk.fromIterable(
+        implicitly[Numeric[A]].toDouble(value) +: values.map(v => implicitly[Numeric[A]].toDouble(v))
+      ),
+      missing = None
+    )
 
   /**
    * Constructs a type-safe instance of [[zio.elasticsearch.aggregation.PercentilesAggregation]] using the specified

--- a/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
@@ -293,7 +293,7 @@ sealed trait PercentileRanksAggregation
 private[elasticsearch] final case class PercentileRanks(
   name: String,
   field: String,
-  values: Chunk[Int],
+  values: Chunk[Double],
   missing: Option[Double]
 ) extends PercentileRanksAggregation { self =>
 

--- a/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
@@ -293,7 +293,7 @@ sealed trait PercentileRanksAggregation
 private[elasticsearch] final case class PercentileRanks(
   name: String,
   field: String,
-  values: Chunk[Double],
+  values: Chunk[BigDecimal],
   missing: Option[Double]
 ) extends PercentileRanksAggregation { self =>
 

--- a/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/aggregation/Aggregations.scala
@@ -291,8 +291,8 @@ sealed trait PercentileRanksAggregation
     with WithAgg
 
 private[elasticsearch] final case class PercentileRanks(
-  field: String,
   name: String,
+  field: String,
   values: Chunk[Int],
   missing: Option[Double]
 ) extends PercentileRanksAggregation { self =>
@@ -325,7 +325,7 @@ sealed trait PercentilesAggregation
    * Sets the `percents` parameter for the [[zio.elasticsearch.aggregation.PercentilesAggregation]].
    *
    * @param percents
-   *   a array of percentiles to be calculated for [[zio.elasticsearch.aggregation.PercentilesAggregation]]
+   *   an array of percentiles to be calculated for [[zio.elasticsearch.aggregation.PercentilesAggregation]]
    * @return
    *   an instance of the [[zio.elasticsearch.aggregation.PercentilesAggregation]] enriched with the `percents`
    *   parameter.

--- a/modules/library/src/main/scala/zio/elasticsearch/executor/response/AggregationResponse.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/executor/response/AggregationResponse.scala
@@ -83,6 +83,8 @@ object AggregationResponse {
         MinAggregationResult(value)
       case MissingAggregationResponse(value) =>
         MissingAggregationResult(value)
+      case PercentileRanksAggregationResponse(values) =>
+        PercentileRanksAggregationResult(values)
       case PercentilesAggregationResponse(values) =>
         PercentilesAggregationResult(values)
       case StatsAggregationResponse(count, min, max, avg, sum) =>
@@ -287,6 +289,14 @@ private[elasticsearch] object MissingAggregationResponse {
   implicit val decoder: JsonDecoder[MissingAggregationResponse] = DeriveJsonDecoder.gen[MissingAggregationResponse]
 }
 
+private[elasticsearch] final case class PercentileRanksAggregationResponse(values: Map[String, Double])
+    extends AggregationResponse
+
+private[elasticsearch] object PercentileRanksAggregationResponse {
+  implicit val decoder: JsonDecoder[PercentileRanksAggregationResponse] =
+    DeriveJsonDecoder.gen[PercentileRanksAggregationResponse]
+}
+
 private[elasticsearch] final case class PercentilesAggregationResponse(values: Map[String, Double])
     extends AggregationResponse
 
@@ -396,6 +406,10 @@ private[elasticsearch] object TermsAggregationBucket extends JsonDecoderOps {
               Some(field -> MinAggregationResponse(value = objFields("value").unsafeAs[Double]))
             case str if str.contains("missing#") =>
               Some(field -> MissingAggregationResponse(docCount = objFields("doc_count").unsafeAs[Int]))
+            case str if str.contains("percentile_ranks#") =>
+              Some(
+                field -> PercentileRanksAggregationResponse(values = objFields("values").unsafeAs[Map[String, Double]])
+              )
             case str if str.contains("percentiles#") =>
               Some(field -> PercentilesAggregationResponse(values = objFields("values").unsafeAs[Map[String, Double]]))
             case str if str.contains("stats#") =>
@@ -439,6 +453,8 @@ private[elasticsearch] object TermsAggregationBucket extends JsonDecoderOps {
             (field.split("#")(1), data.asInstanceOf[MinAggregationResponse])
           case str if str.contains("missing#") =>
             (field.split("#")(1), data.asInstanceOf[MissingAggregationResponse])
+          case str if str.contains("percentile_ranks#") =>
+            (field.split("#")(1), data.asInstanceOf[PercentileRanksAggregationResponse])
           case str if str.contains("percentiles#") =>
             (field.split("#")(1), data.asInstanceOf[PercentilesAggregationResponse])
           case str if str.contains("stats#") =>

--- a/modules/library/src/main/scala/zio/elasticsearch/executor/response/AggregationResponse.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/executor/response/AggregationResponse.scala
@@ -203,6 +203,10 @@ private[elasticsearch] object FilterAggregationResponse extends JsonDecoderOps {
               Some(field -> MinAggregationResponse(value = objFields("value").unsafeAs[Double]))
             case str if str.contains("missing#") =>
               Some(field -> MissingAggregationResponse(docCount = objFields("doc_count").unsafeAs[Int]))
+            case str if str.contains("percentile_ranks#") =>
+              Some(
+                field -> PercentileRanksAggregationResponse(values = objFields("values").unsafeAs[Map[String, Double]])
+              )
             case str if str.contains("percentiles#") =>
               Some(field -> PercentilesAggregationResponse(values = objFields("values").unsafeAs[Map[String, Double]]))
             case str if str.contains("stats#") =>
@@ -245,6 +249,8 @@ private[elasticsearch] object FilterAggregationResponse extends JsonDecoderOps {
             (field.split("#")(1), data.asInstanceOf[MinAggregationResponse])
           case str if str.contains("missing#") =>
             (field.split("#")(1), data.asInstanceOf[MissingAggregationResponse])
+          case str if str.contains("percentile_ranks#") =>
+            (field.split("#")(1), data.asInstanceOf[PercentileRanksAggregationResponse])
           case str if str.contains("percentiles#") =>
             (field.split("#")(1), data.asInstanceOf[PercentilesAggregationResponse])
           case str if str.contains("stats#") =>

--- a/modules/library/src/main/scala/zio/elasticsearch/executor/response/SearchWithAggregationsResponse.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/executor/response/SearchWithAggregationsResponse.scala
@@ -88,6 +88,8 @@ private[elasticsearch] final case class SearchWithAggregationsResponse(
                       MinAggregationResponse.decoder.decodeJson(data.toString).map(field.split("#")(1) -> _)
                     case str if str.contains("missing#") =>
                       MissingAggregationResponse.decoder.decodeJson(data.toString).map(field.split("#")(1) -> _)
+                    case str if str.contains("percentile_ranks#") =>
+                      PercentileRanksAggregationResponse.decoder.decodeJson(data.toString).map(field.split("#")(1) -> _)
                     case str if str.contains("percentiles#") =>
                       PercentilesAggregationResponse.decoder.decodeJson(data.toString).map(field.split("#")(1) -> _)
                     case str if str.contains("stats#") =>

--- a/modules/library/src/main/scala/zio/elasticsearch/package.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/package.scala
@@ -115,6 +115,18 @@ package object elasticsearch extends IndexNameNewtype with IndexPatternNewtype w
      *   the name of the aggregation to retrieve
      * @return
      *   a [[RIO]] effect that, when executed, will produce the aggregation as instance of
+     *   [[result.PercentileRanksAggregationResult]].
+     */
+    def asPercentileRanksAggregation(name: String): RIO[R, Option[PercentileRanksAggregationResult]] =
+      aggregationAs[PercentileRanksAggregationResult](name)
+
+    /**
+     * Executes the [[ElasticRequest.SearchRequest]] or the [[ElasticRequest.SearchAndAggregateRequest]].
+     *
+     * @param name
+     *   the name of the aggregation to retrieve
+     * @return
+     *   a [[RIO]] effect that, when executed, will produce the aggregation as instance of
      *   [[result.PercentilesAggregationResult]].
      */
     def asPercentilesAggregation(name: String): RIO[R, Option[PercentilesAggregationResult]] =

--- a/modules/library/src/main/scala/zio/elasticsearch/result/AggregationResult.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/result/AggregationResult.scala
@@ -65,6 +65,9 @@ final case class MinAggregationResult private[elasticsearch] (value: Double) ext
 
 final case class MissingAggregationResult private[elasticsearch] (docCount: Int) extends AggregationResult
 
+final case class PercentileRanksAggregationResult private[elasticsearch] (values: Map[String, Double])
+    extends AggregationResult
+
 final case class PercentilesAggregationResult private[elasticsearch] (values: Map[String, Double])
     extends AggregationResult
 

--- a/modules/library/src/main/scala/zio/elasticsearch/result/ElasticResult.scala
+++ b/modules/library/src/main/scala/zio/elasticsearch/result/ElasticResult.scala
@@ -57,6 +57,9 @@ private[elasticsearch] sealed trait ResultWithAggregation {
   def asMinAggregation(name: String): IO[DecodingException, Option[MinAggregationResult]] =
     aggregationAs[MinAggregationResult](name)
 
+  def asPercentileRanksAggregation(name: String): IO[DecodingException, Option[PercentileRanksAggregationResult]] =
+    aggregationAs[PercentileRanksAggregationResult](name)
+
   def asPercentilesAggregation(name: String): IO[DecodingException, Option[PercentilesAggregationResult]] =
     aggregationAs[PercentilesAggregationResult](name)
 

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticAggregationSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticAggregationSpec.scala
@@ -286,24 +286,24 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
           )
         },
         test("percentileRanks") {
-          val aggregation      = percentileRanksAggregation("testField", "aggregation", 5, 6)
-          val aggregationTs    = percentileRanksAggregation(TestSubDocument.intField, "aggregation", 5, 6)
-          val aggregationTsRaw = percentileRanksAggregation(TestSubDocument.intField.raw, "aggregation", 5, 6)
+          val aggregation      = percentileRanksAggregation("aggregation", "testField", 5, 6)
+          val aggregationTs    = percentileRanksAggregation("aggregation", TestSubDocument.intField, 5, 6)
+          val aggregationTsRaw = percentileRanksAggregation("aggregation", TestSubDocument.intField.raw, 5, 6)
           val aggregationWithMissing =
-            percentileRanksAggregation(TestSubDocument.intField, "aggregation", 5, 6).missing(20.0)
+            percentileRanksAggregation("aggregation", TestSubDocument.intField, 5, 6).missing(20.0)
 
           assert(aggregation)(
-            equalTo(PercentileRanks(field = "testField", name = "aggregation", values = Chunk(5, 6), missing = None))
+            equalTo(PercentileRanks(name = "aggregation", field = "testField", values = Chunk(5, 6), missing = None))
           ) &&
           assert(aggregationTs)(
-            equalTo(PercentileRanks(field = "intField", name = "aggregation", values = Chunk(5, 6), missing = None))
+            equalTo(PercentileRanks(name = "aggregation", field = "intField", values = Chunk(5, 6), missing = None))
           ) &&
           assert(aggregationTsRaw)(
-            equalTo(PercentileRanks(field = "intField.raw", name = "aggregation", values = Chunk(5, 6), missing = None))
+            equalTo(PercentileRanks(name = "aggregation", field = "intField.raw", values = Chunk(5, 6), missing = None))
           ) &&
           assert(aggregationWithMissing)(
             equalTo(
-              PercentileRanks(field = "intField", name = "aggregation", values = Chunk(5, 6), missing = Some(20.0))
+              PercentileRanks(name = "aggregation", field = "intField", values = Chunk(5, 6), missing = Some(20.0))
             )
           )
         },
@@ -1144,10 +1144,10 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
           assert(aggregationWithSubAggregation.toJson)(equalTo(expectedWithSubAggregation.toJson))
         },
         test("percentileRanks") {
-          val aggregation   = percentileRanksAggregation("testField", "aggregation", 5, 6)
-          val aggregationTs = percentileRanksAggregation(TestSubDocument.intField, "aggregation", 5, 6)
+          val aggregation   = percentileRanksAggregation("aggregation", "testField", 5, 6)
+          val aggregationTs = percentileRanksAggregation("aggregation", TestSubDocument.intField, 5, 6)
           val aggregationWithMissing =
-            percentileRanksAggregation(TestSubDocument.intField, "aggregation", 5, 6).missing(20.0)
+            percentileRanksAggregation("aggregation", TestSubDocument.intField, 5, 6).missing(20.0)
 
           val expected =
             """

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticAggregationSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticAggregationSpec.scala
@@ -293,17 +293,21 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
             percentileRanksAggregation("aggregation", TestSubDocument.intField, 5, 6).missing(20.0)
 
           assert(aggregation)(
-            equalTo(PercentileRanks(name = "aggregation", field = "testField", values = Chunk(5, 6), missing = None))
+            equalTo(
+              PercentileRanks(name = "aggregation", field = "testField", values = Chunk(5.0, 6.0), missing = None)
+            )
           ) &&
           assert(aggregationTs)(
-            equalTo(PercentileRanks(name = "aggregation", field = "intField", values = Chunk(5, 6), missing = None))
+            equalTo(PercentileRanks(name = "aggregation", field = "intField", values = Chunk(5.0, 6.0), missing = None))
           ) &&
           assert(aggregationTsRaw)(
-            equalTo(PercentileRanks(name = "aggregation", field = "intField.raw", values = Chunk(5, 6), missing = None))
+            equalTo(
+              PercentileRanks(name = "aggregation", field = "intField.raw", values = Chunk(5.0, 6.0), missing = None)
+            )
           ) &&
           assert(aggregationWithMissing)(
             equalTo(
-              PercentileRanks(name = "aggregation", field = "intField", values = Chunk(5, 6), missing = Some(20.0))
+              PercentileRanks(name = "aggregation", field = "intField", values = Chunk(5.0, 6.0), missing = Some(20.0))
             )
           )
         },
@@ -1155,7 +1159,7 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
               |  "aggregation": {
               |    "percentile_ranks": {
               |      "field": "testField",
-              |      "values": [5, 6]
+              |      "values": [5.0, 6.0]
               |    }
               |  }
               |}
@@ -1167,7 +1171,7 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
               |  "aggregation": {
               |    "percentile_ranks": {
               |      "field": "intField",
-              |      "values": [5, 6]
+              |      "values": [5.0, 6.0]
               |    }
               |  }
               |}
@@ -1179,7 +1183,7 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
               |  "aggregation": {
               |    "percentile_ranks": {
               |      "field": "intField",
-              |      "values": [5, 6],
+              |      "values": [5.0, 6.0],
               |      "missing": 20.0
               |    }
               |  }

--- a/modules/library/src/test/scala/zio/elasticsearch/ElasticAggregationSpec.scala
+++ b/modules/library/src/test/scala/zio/elasticsearch/ElasticAggregationSpec.scala
@@ -1159,7 +1159,7 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
               |  "aggregation": {
               |    "percentile_ranks": {
               |      "field": "testField",
-              |      "values": [5.0, 6.0]
+              |      "values": [5, 6]
               |    }
               |  }
               |}
@@ -1171,7 +1171,7 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
               |  "aggregation": {
               |    "percentile_ranks": {
               |      "field": "intField",
-              |      "values": [5.0, 6.0]
+              |      "values": [5, 6]
               |    }
               |  }
               |}
@@ -1183,7 +1183,7 @@ object ElasticAggregationSpec extends ZIOSpecDefault {
               |  "aggregation": {
               |    "percentile_ranks": {
               |      "field": "intField",
-              |      "values": [5.0, 6.0],
+              |      "values": [5, 6],
               |      "missing": 20.0
               |    }
               |  }

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -55,6 +55,7 @@ module.exports = {
                     'overview/aggregations/elastic_aggregation_max',
                     'overview/aggregations/elastic_aggregation_min',
                     'overview/aggregations/elastic_aggregation_missing',
+                    'overview/aggregations/elastic_aggregation_percentile_ranks',
                     'overview/aggregations/elastic_aggregation_percentiles',
                     'overview/aggregations/elastic_aggregation_stats',
                     'overview/aggregations/elastic_aggregation_sum',


### PR DESCRIPTION
Part of https://github.com/lambdaworks/zio-elasticsearch/issues/118